### PR TITLE
[LOGIC] Spielstart und Spielgeld, Erste Klassen - Game, Player, PlayerInfo #23

### DIFF
--- a/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
@@ -1,4 +1,6 @@
 package at.aau.serg.monopoly.websoket;
+import model.Game;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.NonNull;
 import org.springframework.web.socket.*;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
@@ -10,14 +12,18 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class GameWebSocketHandler extends TextWebSocketHandler {
 
     private final CopyOnWriteArrayList<WebSocketSession> sessions = new CopyOnWriteArrayList<>();
+    private final Game game = new Game();
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
     public void afterConnectionEstablished(@NonNull WebSocketSession session) {
         sessions.add(session);
+        // Add player to game with a default name (can be updated later)
+        game.addPlayer(session.getId(), "Player " + sessions.size());
         broadcastMessage("Player joined: " + session.getId() + " (Total: " + sessions.size() + ")");
 
-        // Check if four players are connected
-        if (sessions.size() == 4) {
+        // Check if 2-4 players are connected
+        if (sessions.size() >= 2 && sessions.size() <= 4) {
             startGame();
         }
 
@@ -44,7 +50,7 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
                 if (session.isOpen()) {
                     session.sendMessage(new TextMessage(message));
                 } else {
-                    sessions.remove(session);  // Inaktive Sitzungen entfernen
+                    sessions.remove(session);  // Remove inactive sessions
                 }
             } catch (Exception e) {
                 System.err.println("Error sending message: " + e.getMessage());
@@ -52,10 +58,16 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
         }
     }
 
-
     private void startGame() {
-        broadcastMessage("Game started! All 4 players are connected.");
-        System.out.println("Game started!");
+        try {
+            // Send initial game state to all players
+            String gameState = objectMapper.writeValueAsString(game.getPlayerInfo());
+            broadcastMessage("GAME_STATE:" + gameState);
+            broadcastMessage("Game started! " + sessions.size() + " players are connected.");
+            System.out.println("Game started with " + sessions.size() + " players!");
+        } catch (Exception e) {
+            System.err.println("Error sending game state: " + e.getMessage());
+        }
     }
 }
 

--- a/src/main/java/model/Game.java
+++ b/src/main/java/model/Game.java
@@ -1,0 +1,37 @@
+package model;
+import lombok.Data;
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+public class Game {
+    private List<Player> players;
+    private boolean isStarted;
+    private int currentPlayerIndex;
+
+    public Game() {
+        this.players = new ArrayList<>();
+        this.isStarted = false;
+        this.currentPlayerIndex = 0;
+    }
+
+    public void addPlayer(String id, String name) {
+        players.add(new Player(id, name));
+    }
+
+    public Player getCurrentPlayer() {
+        return players.get(currentPlayerIndex);
+    }
+
+    public void nextPlayer() {
+        currentPlayerIndex = (currentPlayerIndex + 1) % players.size();
+    }
+
+    public List<PlayerInfo> getPlayerInfo() {
+        List<PlayerInfo> info = new ArrayList<>();
+        for (Player player : players) {
+            info.add(new PlayerInfo(player.getId(), player.getName(), player.getMoney()));
+        }
+        return info;
+    }
+}

--- a/src/main/java/model/Player.java
+++ b/src/main/java/model/Player.java
@@ -1,0 +1,24 @@
+package model;
+import lombok.Data;
+
+@Data
+public class Player {
+    private String id;
+    private String name;
+    private int money;
+    private static final int STARTING_MONEY = 1500; // Standard Monopoly starting money
+
+    public Player(String id, String name) {
+        this.id = id;
+        this.name = name;
+        this.money = STARTING_MONEY;
+    }
+
+    public void addMoney(int amount) {
+        this.money += amount;
+    }
+
+    public void subtractMoney(int amount) {
+        this.money -= amount;
+    }
+}

--- a/src/main/java/model/PlayerInfo.java
+++ b/src/main/java/model/PlayerInfo.java
@@ -1,0 +1,14 @@
+package model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PlayerInfo {
+    private String id;
+    private String name;
+    private int money;
+}

--- a/src/test/java/at/aau/serg/monopoly/websoket/GameWebSocketHandlerUnitTest.java
+++ b/src/test/java/at/aau/serg/monopoly/websoket/GameWebSocketHandlerUnitTest.java
@@ -57,7 +57,7 @@ class GameWebSocketHandlerUnitTest {
         gameWebSocketHandler.afterConnectionEstablished(session3);
         gameWebSocketHandler.afterConnectionEstablished(session4);
 
-    String expectedPayload = "Game started! All 4 players are connected.";
+        String expectedPayload = "Game started! 4 players are connected.";
 
 
         verify(session1, atLeastOnce()).sendMessage(argThat(msg -> msg.getPayload().equals(expectedPayload)));

--- a/src/test/java/at/aau/serg/monopoly/websoket/GameWebSocketIntegrationTest.java
+++ b/src/test/java/at/aau/serg/monopoly/websoket/GameWebSocketIntegrationTest.java
@@ -1,0 +1,94 @@
+package at.aau.serg.monopoly.websoket;
+import model.PlayerInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class GameWebSocketIntegrationTest {
+    @LocalServerPort
+    private int port;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void testGameStartWithTwoPlayers() throws Exception {
+        // Create two WebSocket clients
+        StandardWebSocketClient client1 = new StandardWebSocketClient();
+        StandardWebSocketClient client2 = new StandardWebSocketClient();
+
+        // Create futures to store received messages
+        CompletableFuture<String> client1Future = new CompletableFuture<>();
+        CompletableFuture<String> client2Future = new CompletableFuture<>();
+        List<String> client1Messages = new ArrayList<>();
+        List<String> client2Messages = new ArrayList<>();
+
+        // Connect first client
+        WebSocketSession session1 = client1.doHandshake(new TestWebSocketHandler(client1Future, client1Messages),
+                "ws://localhost:" + port + "/monopoly").get(5, TimeUnit.SECONDS);
+
+        // Connect second client
+        WebSocketSession session2 = client2.doHandshake(new TestWebSocketHandler(client2Future, client2Messages),
+                "ws://localhost:" + port + "/monopoly").get(5, TimeUnit.SECONDS);
+
+        // Wait for game state messages
+        String gameState1 = client1Future.get(5, TimeUnit.SECONDS);
+        String gameState2 = client2Future.get(5, TimeUnit.SECONDS);
+
+        // Verify game state messages
+        assertThat(gameState1).startsWith("GAME_STATE:");
+        assertThat(gameState2).startsWith("GAME_STATE:");
+
+        // Parse and verify player information
+        String json1 = gameState1.substring("GAME_STATE:".length());
+        String json2 = gameState2.substring("GAME_STATE:".length());
+
+        List<PlayerInfo> players1 = objectMapper.readValue(json1,
+                objectMapper.getTypeFactory().constructCollectionType(List.class, PlayerInfo.class));
+        List<PlayerInfo> players2 = objectMapper.readValue(json2,
+                objectMapper.getTypeFactory().constructCollectionType(List.class, PlayerInfo.class));
+
+        // Verify that we have at least 2 players and at most 4 players
+        assertThat(players1.size()).isBetween(2, 4);
+        assertThat(players2.size()).isBetween(2, 4);
+
+        // Verify that all players have the correct starting money
+        for (PlayerInfo player : players1) {
+            assertThat(player.getMoney()).isEqualTo(1500);
+        }
+
+        // Clean up
+        session1.close();
+        session2.close();
+    }
+
+    private static class TestWebSocketHandler extends org.springframework.web.socket.handler.AbstractWebSocketHandler {
+        private final CompletableFuture<String> future;
+        private final List<String> messages;
+
+        public TestWebSocketHandler(CompletableFuture<String> future, List<String> messages) {
+            this.future = future;
+            this.messages = messages;
+        }
+
+        @Override
+        protected void handleTextMessage(WebSocketSession session, TextMessage message) {
+            String payload = message.getPayload();
+            messages.add(payload);
+            if (payload.startsWith("GAME_STATE:")) {
+                future.complete(payload);
+            }
+        }
+    }
+}

--- a/src/test/java/model/GameTest.java
+++ b/src/test/java/model/GameTest.java
@@ -1,0 +1,71 @@
+package model;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GameTest {
+    private Game game;
+
+    @BeforeEach
+    void setUp() {
+        game = new Game();
+    }
+
+    @Test
+    void testAddPlayer() {
+        game.addPlayer("1", "Player 1");
+        game.addPlayer("2", "Player 2");
+
+        assertThat(game.getPlayers()).hasSize(2);
+        assertThat(game.getPlayers().get(0).getName()).isEqualTo("Player 1");
+        assertThat(game.getPlayers().get(1).getName()).isEqualTo("Player 2");
+    }
+
+    @Test
+    void testPlayerMoney() {
+        game.addPlayer("1", "Player 1");
+        Player player = game.getPlayers().get(0);
+
+        assertThat(player.getMoney()).isEqualTo(1500); // Starting money
+
+        player.addMoney(500);
+        assertThat(player.getMoney()).isEqualTo(2000);
+
+        player.subtractMoney(300);
+        assertThat(player.getMoney()).isEqualTo(1700);
+    }
+
+    @Test
+    void testPlayerTurnOrder() {
+        game.addPlayer("1", "Player 1");
+        game.addPlayer("2", "Player 2");
+        game.addPlayer("3", "Player 3");
+
+        assertThat(game.getCurrentPlayer().getName()).isEqualTo("Player 1");
+
+        game.nextPlayer();
+        assertThat(game.getCurrentPlayer().getName()).isEqualTo("Player 2");
+
+        game.nextPlayer();
+        assertThat(game.getCurrentPlayer().getName()).isEqualTo("Player 3");
+
+        game.nextPlayer();
+        assertThat(game.getCurrentPlayer().getName()).isEqualTo("Player 1"); // Should wrap around
+    }
+
+    @Test
+    void testGetPlayerInfo() {
+        game.addPlayer("1", "Player 1");
+        game.addPlayer("2", "Player 2");
+
+        var playerInfo = game.getPlayerInfo();
+
+        assertThat(playerInfo).hasSize(2);
+        assertThat(playerInfo.get(0).getName()).isEqualTo("Player 1");
+        assertThat(playerInfo.get(1).getName()).isEqualTo("Player 2");
+        assertThat(playerInfo.get(0).getMoney()).isEqualTo(1500);
+        assertThat(playerInfo.get(1).getMoney()).isEqualTo(1500);
+    }
+}


### PR DESCRIPTION
Dieses PR implementiert die Registrierung von Spielern beim Beitritt über eine WebSocket-Verbindung sowie den Spielstart.

Neue Spieler werden beim Verbindungsaufbau automatisch zur Game-Instanz hinzugefügt
Jeder Spieler erhält eine eindeutige ID und 1500 Startgeld
Der aktuelle Spielstand wird an alle Clients per "GAME_STATE:"-Nachricht übertragen
Player, Game, PlayerInfo Klassen eingeführt oder erweitert
WebSocket-Handler verarbeitet Verbindungen, Nachrichten und Verbindungsabbrüche
Unit-Tests (GameTest, GameWebSocketHandlerUnitTest) und Integrationstests (GameWebSocketIntegrationTest) hinzugefügt

Referenzen:
#23 (https://github.com/Software-Engineering-II-Gruppe2/WebSocketBroker-App/issues/23)
