### PR TITLE
146 grundstücke kaufen

### DIFF
--- a/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
@@ -54,7 +54,7 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
                 logger.info("Player " + playerId + " rolled " + roll);
 
                 DiceRollMessage drm = new DiceRollMessage(playerId, roll);
-                String json = null;
+                String json;
                 try {
                     json = objectMapper.writeValueAsString(drm);
                 } catch (JsonProcessingException e) {
@@ -141,7 +141,7 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
                 boolean success = propertyTransactionService.buyProperty(player, propertyId);
                 if (success) {
                     logger.info("Property " + propertyId + " bought successfully by player " + playerId);
-                    broadcastMessage(createJsonMessage("PROPERTY_BOUGHT", "Player " + playerId + " bought property " + propertyId));
+                    broadcastMessage(createJsonMessage("Player " + playerId + " bought property " + propertyId));
                     broadcastGameState();
                 } else {
                     logger.warning("Property purchase failed for player " + playerId + ", property " + propertyId + " after canBuy check.");
@@ -175,8 +175,8 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
         return "{\"type\":\"ERROR\", \"message\":\"" + escapeJson(errorMessage) + "\"}";
     }
 
-    private String createJsonMessage(String type, String message) {
-        return "{\"type\":\""+ escapeJson(type) +"\", \"message\":\"" + escapeJson(message) + "\"}";
+    private String createJsonMessage(String message) {
+        return "{\"type\":\""+ escapeJson("PROPERTY_BOUGHT") +"\", \"message\":\"" + escapeJson(message) + "\"}";
     }
 
     private String escapeJson(String value) {

--- a/src/main/java/at/aau/serg/monopoly/websoket/PropertyTransactionService.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/PropertyTransactionService.java
@@ -1,0 +1,56 @@
+package at.aau.serg.monopoly.websoket;
+import model.Player;
+import model.properties.BaseProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PropertyTransactionService {
+
+    @Autowired
+    private PropertyService propertyService;
+
+    /**
+     * Checks if a player can buy a specific property
+     * @param player The player attempting to buy
+     * @param propertyId The ID of the property to buy
+     * @return true if the player can buy the property, false otherwise
+     */
+    public boolean canBuyProperty(Player player, int propertyId) {
+        BaseProperty property = findPropertyById(propertyId);
+
+        if (property == null) {
+            return false;
+        }
+
+        // Check if property is unowned and player has enough money
+        return property.getOwnerId() == null &&
+                player.getMoney() >= property.getPurchasePrice();
+    }
+
+    /**
+     * Helper method to find a property by its ID across all property types
+     */
+    private BaseProperty findPropertyById(int propertyId) {
+        // Check houseable properties
+        BaseProperty property = propertyService.getHouseablePropertyById(propertyId);
+        if (property != null) {
+            return property;
+        }
+
+        // Check train stations
+        property = propertyService.getTrainStations().stream()
+                .filter(p -> p.getId() == propertyId)
+                .findFirst()
+                .orElse(null);
+        if (property != null) {
+            return property;
+        }
+
+        // Check utilities
+        return propertyService.getUtilities().stream()
+                .filter(p -> p.getId() == propertyId)
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/src/main/java/at/aau/serg/monopoly/websoket/PropertyTransactionService.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/PropertyTransactionService.java
@@ -3,9 +3,12 @@ import model.Player;
 import model.properties.BaseProperty;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import java.util.logging.Logger;
 
 @Service
 public class PropertyTransactionService {
+
+    private static final Logger logger = Logger.getLogger(PropertyTransactionService.class.getName());
 
     @Autowired
     private PropertyService propertyService;
@@ -26,6 +29,47 @@ public class PropertyTransactionService {
         // Check if property is unowned and player has enough money
         return property.getOwnerId() == null &&
                 player.getMoney() >= property.getPurchasePrice();
+    }
+
+    /**
+     * Executes the purchase of a property for a player.
+     * Assumes validation (canBuyProperty) has already passed.
+     * @param player The player buying the property.
+     * @param propertyId The ID of the property being bought.
+     * @return true if the purchase was successful, false otherwise.
+     */
+    public boolean buyProperty(Player player, int propertyId) {
+        BaseProperty property = findPropertyById(propertyId);
+
+        // Double-check conditions in case state changed
+        if (property == null || property.getOwnerId() != null || player.getMoney() < property.getPurchasePrice()) {
+             logger.warning("Attempted to buy property " + propertyId + " by player " + player.getId() + " failed pre-check.");
+            return false; // Should not happen if canBuyProperty was called first, but good practice
+        }
+
+        try {
+            // Convert player ID string to Integer for ownerId
+            // THIS MIGHT FAIL if player.getId() is not a parsable integer!
+            // TODO: Confirm if player IDs are integers or if BaseProperty.ownerId needs to be String
+            Integer playerIdInt = Integer.parseInt(player.getId()); 
+
+            // Perform transaction
+            player.subtractMoney(property.getPurchasePrice());
+            property.setOwnerId(playerIdInt);
+
+            logger.info("Player " + player.getId() + " successfully bought property " + propertyId + 
+                        ". New balance: " + player.getMoney());
+            return true;
+
+        } catch (NumberFormatException e) {
+            // Log error if player ID cannot be parsed to Integer
+             logger.severe("Failed to parse player ID '" + player.getId() + "' to Integer for property ownership.");
+            return false;
+        } catch (Exception e) {
+             logger.severe("An unexpected error occurred during property purchase: " + e.getMessage());
+            // Potentially revert changes if partial transaction occurred, though unlikely here.
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/at/aau/serg/monopoly/websoket/PropertyTransactionService.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/PropertyTransactionService.java
@@ -3,6 +3,8 @@ import model.Player;
 import model.properties.BaseProperty;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 @Service
@@ -42,7 +44,7 @@ public class PropertyTransactionService {
 
         // Double-check conditions in case state changed
         if (property == null || property.getOwnerId() != null || player.getMoney() < property.getPurchasePrice()) {
-            logger.warning("Attempted to buy property " + propertyId + " by player " + player.getId() + " failed pre-check.");
+            logger.log(Level.WARNING, "Attempted to buy property {0} by player {1} failed pre-check.", new Object[]{propertyId, player.getId()});
             return false;
         }
 
@@ -51,12 +53,12 @@ public class PropertyTransactionService {
             player.subtractMoney(property.getPurchasePrice());
             property.setOwnerId(player.getId());
 
-            logger.info("Player " + player.getId() + " successfully bought property " + propertyId + 
-                      ". New balance: " + player.getMoney());
+            logger.log(Level.INFO, "Player {0} successfully bought property {1}. New balance: {2}",
+                    new Object[]{player.getId(), propertyId, player.getMoney()});
             return true;
 
         } catch (Exception e) {
-            logger.severe("An unexpected error occurred during property purchase: " + e.getMessage());
+            logger.log(Level.SEVERE, "An unexpected error occurred during property purchase: {0}", e.getMessage());
             return false;
         }
     }

--- a/src/main/java/at/aau/serg/monopoly/websoket/PropertyTransactionService.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/PropertyTransactionService.java
@@ -64,7 +64,7 @@ public class PropertyTransactionService {
     /**
      * Helper method to find a property by its ID across all property types
      */
-    private BaseProperty findPropertyById(int propertyId) {
+    BaseProperty findPropertyById(int propertyId) {
         // Check houseable properties
         BaseProperty property = propertyService.getHouseablePropertyById(propertyId);
         if (property != null) {

--- a/src/main/java/at/aau/serg/monopoly/websoket/PropertyTransactionService.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/PropertyTransactionService.java
@@ -33,7 +33,6 @@ public class PropertyTransactionService {
 
     /**
      * Executes the purchase of a property for a player.
-     * Assumes validation (canBuyProperty) has already passed.
      * @param player The player buying the property.
      * @param propertyId The ID of the property being bought.
      * @return true if the purchase was successful, false otherwise.
@@ -43,31 +42,21 @@ public class PropertyTransactionService {
 
         // Double-check conditions in case state changed
         if (property == null || property.getOwnerId() != null || player.getMoney() < property.getPurchasePrice()) {
-             logger.warning("Attempted to buy property " + propertyId + " by player " + player.getId() + " failed pre-check.");
-            return false; // Should not happen if canBuyProperty was called first, but good practice
+            logger.warning("Attempted to buy property " + propertyId + " by player " + player.getId() + " failed pre-check.");
+            return false;
         }
 
         try {
-            // Convert player ID string to Integer for ownerId
-            // THIS MIGHT FAIL if player.getId() is not a parsable integer!
-            // TODO: Confirm if player IDs are integers or if BaseProperty.ownerId needs to be String
-            Integer playerIdInt = Integer.parseInt(player.getId()); 
-
-            // Perform transaction
+            // Perform transaction - directly use player ID as owner ID
             player.subtractMoney(property.getPurchasePrice());
-            property.setOwnerId(playerIdInt);
+            property.setOwnerId(player.getId());
 
             logger.info("Player " + player.getId() + " successfully bought property " + propertyId + 
-                        ". New balance: " + player.getMoney());
+                      ". New balance: " + player.getMoney());
             return true;
 
-        } catch (NumberFormatException e) {
-            // Log error if player ID cannot be parsed to Integer
-             logger.severe("Failed to parse player ID '" + player.getId() + "' to Integer for property ownership.");
-            return false;
         } catch (Exception e) {
-             logger.severe("An unexpected error occurred during property purchase: " + e.getMessage());
-            // Potentially revert changes if partial transaction occurred, though unlikely here.
+            logger.severe("An unexpected error occurred during property purchase: " + e.getMessage());
             return false;
         }
     }

--- a/src/main/java/model/Game.java
+++ b/src/main/java/model/Game.java
@@ -2,6 +2,7 @@ package model;
 import lombok.Data;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Data
 public class Game {
@@ -46,5 +47,16 @@ public class Game {
             info.add(new PlayerInfo(player.getId(), player.getName(), player.getMoney()));
         }
         return info;
+    }
+
+    /**
+     * Finds a player by their unique ID.
+     * @param id The ID of the player to find.
+     * @return An Optional containing the Player if found, otherwise empty.
+     */
+    public Optional<Player> getPlayerById(String id) {
+        return players.stream()
+                      .filter(player -> player.getId().equals(id))
+                      .findFirst();
     }
 }

--- a/src/main/java/model/properties/BaseProperty.java
+++ b/src/main/java/model/properties/BaseProperty.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @AllArgsConstructor
 public abstract class BaseProperty {
     protected int id;
-    protected Integer ownerId; // kann null sein
+    protected String ownerId; // Changed from Integer to String
     protected String name;
     protected int purchasePrice;
     protected int mortgageValue;

--- a/src/main/java/model/properties/HouseableProperty.java
+++ b/src/main/java/model/properties/HouseableProperty.java
@@ -15,7 +15,7 @@ public class HouseableProperty extends BaseProperty {
     private int housePrice;
     private int hotelPrice;
 
-    public HouseableProperty(int id, Integer ownerId, String name, int purchasePrice,
+    public HouseableProperty(int id, String ownerId, String name, int purchasePrice,
                              int baseRent, int rent1House, int rent2Houses, int rent3Houses,
                              int rent4Houses, int rentHotel, int housePrice, int hotelPrice,
                              int mortgageValue, boolean isMortgaged, String image) {

--- a/src/main/java/model/properties/TrainStation.java
+++ b/src/main/java/model/properties/TrainStation.java
@@ -11,7 +11,7 @@ public class TrainStation extends BaseProperty {
     private int rent3Stations;
     private int rent4Stations;
 
-    public TrainStation(int id, Integer ownerId, String name, int purchasePrice,
+    public TrainStation(int id, String ownerId, String name, int purchasePrice,
                         int baseRent, int rent2Stations, int rent3Stations, int rent4Stations,
                         int mortgageValue, boolean isMortgaged, String image) {
         super(id, ownerId, name, purchasePrice, mortgageValue, image, isMortgaged);

--- a/src/main/java/model/properties/Utility.java
+++ b/src/main/java/model/properties/Utility.java
@@ -9,7 +9,7 @@ public class Utility extends BaseProperty {
     private int rentOneUtilityMultiplier;
     private int rentTwoUtilitiesMultiplier;
 
-    public Utility(int id, Integer ownerId, String name, int purchasePrice,
+    public Utility(int id, String ownerId, String name, int purchasePrice,
                    int rentOneUtilityMultiplier, int rentTwoUtilitiesMultiplier,
                    int mortgageValue, boolean isMortgaged, String image) {
         super(id, ownerId, name, purchasePrice, mortgageValue, image, isMortgaged);

--- a/src/test/java/at/aau/serg/monopoly/websoket/GameWebSocketHandlerUnitTest.java
+++ b/src/test/java/at/aau/serg/monopoly/websoket/GameWebSocketHandlerUnitTest.java
@@ -15,6 +15,7 @@ import org.springframework.web.socket.WebSocketSession;
 
 import java.io.IOException;
 
+
 import static org.mockito.Mockito.*;
 
 

--- a/src/test/java/at/aau/serg/monopoly/websoket/GameWebSocketHandlerUnitTest.java
+++ b/src/test/java/at/aau/serg/monopoly/websoket/GameWebSocketHandlerUnitTest.java
@@ -127,9 +127,12 @@ class GameWebSocketHandlerUnitTest {
             handler.afterConnectionEstablished(session);
 
             TextMessage rollMsg = new TextMessage("Roll");
+            handler.handleTextMessage(session, rollMsg);
 
-            Executable invocation = () -> handler.handleTextMessage(session, rollMsg);
-            assertThrows(RuntimeException.class, invocation);
+            // Verify error message was sent to the client
+            verify(session).sendMessage(argThat(message -> 
+                ((TextMessage)message).getPayload().contains("\"type\":\"ERROR\"") &&
+                ((TextMessage)message).getPayload().contains("Server error processing your request")));
         }
     }
 
@@ -302,6 +305,102 @@ class GameWebSocketHandlerUnitTest {
             ((TextMessage)msg).getPayload().startsWith("GAME_STATE:")));
         verify(session4, atLeastOnce()).sendMessage(argThat(msg -> 
             ((TextMessage)msg).getPayload().startsWith("GAME_STATE:")));
+    }
+
+    @Test
+    void testHandleBuyProperty_SuccessfulPurchase() throws Exception {
+        // Setup
+        PropertyTransactionService propertyService = mock(PropertyTransactionService.class);
+        // Use reflection to set the mocked service
+        java.lang.reflect.Field field = GameWebSocketHandler.class.getDeclaredField("propertyTransactionService");
+        field.setAccessible(true);
+        field.set(gameWebSocketHandler, propertyService);
+
+        // Setup successful purchase scenario
+        when(propertyService.canBuyProperty(any(), eq(1))).thenReturn(true);
+        when(propertyService.buyProperty(any(), eq(1))).thenReturn(true);
+
+        // Connect player and attempt purchase
+        gameWebSocketHandler.afterConnectionEstablished(session);
+        TextMessage buyMessage = new TextMessage("BUY_PROPERTY:1");
+        gameWebSocketHandler.handleTextMessage(session, buyMessage);
+
+        // Verify success message was broadcast and game state updated
+        verify(session, atLeastOnce()).sendMessage(argThat(msg ->
+                ((TextMessage)msg).getPayload().contains("PROPERTY_BOUGHT")));
+        verify(session, atLeastOnce()).sendMessage(argThat(msg ->
+                ((TextMessage)msg).getPayload().startsWith("GAME_STATE:")));
+    }
+
+    @Test
+    void testHandleBuyProperty_InsufficientFunds() throws Exception {
+        // Setup
+        PropertyTransactionService propertyService = mock(PropertyTransactionService.class);
+        java.lang.reflect.Field field = GameWebSocketHandler.class.getDeclaredField("propertyTransactionService");
+        field.setAccessible(true);
+        field.set(gameWebSocketHandler, propertyService);
+
+        // Setup insufficient funds scenario
+        when(propertyService.canBuyProperty(any(), eq(1))).thenReturn(false);
+
+        // Connect player and attempt purchase
+        gameWebSocketHandler.afterConnectionEstablished(session);
+        TextMessage buyMessage = new TextMessage("BUY_PROPERTY:1");
+        gameWebSocketHandler.handleTextMessage(session, buyMessage);
+
+        // Verify error message was sent only to the buying player
+        verify(session, atLeastOnce()).sendMessage(argThat(msg ->
+                ((TextMessage)msg).getPayload().contains("Cannot buy property")));
+    }
+
+    @Test
+    void testHandleBuyProperty_InvalidPropertyId() throws Exception {
+        // Connect player and attempt purchase with invalid ID
+        gameWebSocketHandler.afterConnectionEstablished(session);
+        TextMessage buyMessage = new TextMessage("BUY_PROPERTY:invalid");
+        gameWebSocketHandler.handleTextMessage(session, buyMessage);
+
+        // Verify error message was sent
+        verify(session, atLeastOnce()).sendMessage(argThat(msg ->
+                ((TextMessage)msg).getPayload().contains("Invalid property ID format")));
+    }
+
+    @Test
+    void testHandleBuyProperty_PlayerNotFound() throws Exception {
+        // Setup with a session ID that won't be in the game
+        WebSocketSession unknownSession = mock(WebSocketSession.class);
+        when(unknownSession.getId()).thenReturn("unknown");
+        when(unknownSession.isOpen()).thenReturn(true);
+
+        // Attempt purchase without connecting first
+        TextMessage buyMessage = new TextMessage("BUY_PROPERTY:1");
+        gameWebSocketHandler.handleTextMessage(unknownSession, buyMessage);
+
+        // Verify error message was sent
+        verify(unknownSession, atLeastOnce()).sendMessage(argThat(msg ->
+                ((TextMessage)msg).getPayload().contains("Player not found")));
+    }
+
+    @Test
+    void testHandleBuyProperty_ServiceFailure() throws Exception {
+        // Setup
+        PropertyTransactionService propertyService = mock(PropertyTransactionService.class);
+        java.lang.reflect.Field field = GameWebSocketHandler.class.getDeclaredField("propertyTransactionService");
+        field.setAccessible(true);
+        field.set(gameWebSocketHandler, propertyService);
+
+        // Setup scenario where canBuy passes but actual purchase fails
+        when(propertyService.canBuyProperty(any(), eq(1))).thenReturn(true);
+        when(propertyService.buyProperty(any(), eq(1))).thenReturn(false);
+
+        // Connect player and attempt purchase
+        gameWebSocketHandler.afterConnectionEstablished(session);
+        TextMessage buyMessage = new TextMessage("BUY_PROPERTY:1");
+        gameWebSocketHandler.handleTextMessage(session, buyMessage);
+
+        // Verify error message was sent
+        verify(session, atLeastOnce()).sendMessage(argThat(msg ->
+                ((TextMessage)msg).getPayload().contains("Failed to buy property due to server error")));
     }
 
     @AfterEach

--- a/src/test/java/at/aau/serg/monopoly/websoket/GameWebSocketHandlerUnitTest.java
+++ b/src/test/java/at/aau/serg/monopoly/websoket/GameWebSocketHandlerUnitTest.java
@@ -7,7 +7,6 @@ import model.DiceManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 import org.mockito.MockedConstruction;
 import org.mockito.Mockito;
 import org.springframework.web.socket.CloseStatus;
@@ -16,7 +15,6 @@ import org.springframework.web.socket.WebSocketSession;
 
 import java.io.IOException;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 

--- a/src/test/java/at/aau/serg/monopoly/websoket/PropertyTransactionServiceTest.java
+++ b/src/test/java/at/aau/serg/monopoly/websoket/PropertyTransactionServiceTest.java
@@ -1,0 +1,177 @@
+package at.aau.serg.monopoly.websoket;
+
+import model.Player;
+import model.properties.BaseProperty;
+import model.properties.HouseableProperty; // Using a concrete subclass for testing
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class) // Initialize Mockito
+class PropertyTransactionServiceTest {
+
+    @Mock // Mock the dependency
+    private PropertyService propertyService;
+
+    @InjectMocks // Inject the mock into the service under test
+    private PropertyTransactionService propertyTransactionService;
+
+    private Player testPlayer;
+    private HouseableProperty testProperty; // Use a concrete type for setup
+
+    // Test constants
+    private static final int PROPERTY_ID = 1;
+    private static final int PURCHASE_PRICE = 100;
+    private static final int MORTGAGE_VALUE = 50;
+    private static final String PLAYER_ID = "player123";
+    private static final String PROPERTY_NAME = "Test Street";
+
+    @BeforeEach
+    void setUp() {
+        // Reset mocks and setup test objects before each test
+        testPlayer = new Player(PLAYER_ID, "Test Player");
+        testProperty = new HouseableProperty(
+                PROPERTY_ID, null, PROPERTY_NAME, PURCHASE_PRICE, // Initially unowned (null ownerId)
+                10, 20, 30, 40, 50, 60, 50, 50, // Rent/house prices (example values)
+                MORTGAGE_VALUE, false, "image"
+        );
+
+        // Ensure collections are empty if methods like getTrainStations are called
+        lenient().when(propertyService.getTrainStations()).thenReturn(Collections.emptyList());
+        lenient().when(propertyService.getUtilities()).thenReturn(Collections.emptyList());
+    }
+
+    // --- Tests for canBuyProperty ---
+
+    @Test
+    void canBuyProperty_SufficientFunds_Unowned_ReturnsTrue() {
+        testPlayer.setMoney(PURCHASE_PRICE + 50); // Player has more than enough
+        when(propertyService.getHouseablePropertyById(PROPERTY_ID)).thenReturn(testProperty);
+
+        assertTrue(propertyTransactionService.canBuyProperty(testPlayer, PROPERTY_ID));
+    }
+
+    @Test
+    void canBuyProperty_ExactFunds_Unowned_ReturnsTrue() {
+        testPlayer.setMoney(PURCHASE_PRICE); // Player has exact amount
+        when(propertyService.getHouseablePropertyById(PROPERTY_ID)).thenReturn(testProperty);
+
+        assertTrue(propertyTransactionService.canBuyProperty(testPlayer, PROPERTY_ID));
+    }
+
+    @Test
+    void canBuyProperty_InsufficientFunds_Unowned_ReturnsFalse() {
+        testPlayer.setMoney(PURCHASE_PRICE - 1); // Player has less than needed
+        when(propertyService.getHouseablePropertyById(PROPERTY_ID)).thenReturn(testProperty);
+
+        assertFalse(propertyTransactionService.canBuyProperty(testPlayer, PROPERTY_ID));
+    }
+
+    @Test
+    void canBuyProperty_SufficientFunds_Owned_ReturnsFalse() {
+        testPlayer.setMoney(PURCHASE_PRICE + 50);
+        testProperty.setOwnerId("anotherPlayer"); // Property is already owned
+        when(propertyService.getHouseablePropertyById(PROPERTY_ID)).thenReturn(testProperty);
+
+        assertFalse(propertyTransactionService.canBuyProperty(testPlayer, PROPERTY_ID));
+    }
+
+    @Test
+    void canBuyProperty_PropertyNotFound_ReturnsFalse() {
+        testPlayer.setMoney(PURCHASE_PRICE + 50);
+        // Mock to return null when property ID is requested
+        when(propertyService.getHouseablePropertyById(PROPERTY_ID)).thenReturn(null);
+        // Ensure other lookups also return null/empty
+        when(propertyService.getTrainStations()).thenReturn(Collections.emptyList());
+        when(propertyService.getUtilities()).thenReturn(Collections.emptyList());
+
+
+        assertFalse(propertyTransactionService.canBuyProperty(testPlayer, PROPERTY_ID));
+        // Verify that all property lookup methods were potentially called by findPropertyById
+        verify(propertyService).getHouseablePropertyById(PROPERTY_ID);
+        verify(propertyService).getTrainStations();
+        verify(propertyService).getUtilities();
+
+    }
+
+    // --- Tests for buyProperty ---
+
+    @Test
+    void buyProperty_SuccessfulPurchase() {
+        testPlayer.setMoney(PURCHASE_PRICE + 50);
+        when(propertyService.getHouseablePropertyById(PROPERTY_ID)).thenReturn(testProperty);
+
+        boolean result = propertyTransactionService.buyProperty(testPlayer, PROPERTY_ID);
+
+        assertTrue(result);
+        assertEquals(50, testPlayer.getMoney()); // Money should be deducted
+        assertEquals(PLAYER_ID, testProperty.getOwnerId()); // Owner ID should be set
+        assertFalse(testProperty.isMortgaged()); // Ensure mortgage status didn't change
+    }
+
+    @Test
+    void buyProperty_InsufficientFunds_FailsPreCheck() {
+        testPlayer.setMoney(PURCHASE_PRICE - 1);
+        when(propertyService.getHouseablePropertyById(PROPERTY_ID)).thenReturn(testProperty);
+
+        boolean result = propertyTransactionService.buyProperty(testPlayer, PROPERTY_ID);
+
+        assertFalse(result);
+        assertEquals(PURCHASE_PRICE - 1, testPlayer.getMoney()); // Money should not change
+        assertNull(testProperty.getOwnerId()); // Owner ID should remain null
+    }
+
+    @Test
+    void buyProperty_AlreadyOwned_FailsPreCheck() {
+        testPlayer.setMoney(PURCHASE_PRICE + 50);
+        testProperty.setOwnerId("anotherPlayer");
+        when(propertyService.getHouseablePropertyById(PROPERTY_ID)).thenReturn(testProperty);
+
+        boolean result = propertyTransactionService.buyProperty(testPlayer, PROPERTY_ID);
+
+        assertFalse(result);
+        assertEquals(PURCHASE_PRICE + 50, testPlayer.getMoney()); // Money should not change
+        assertEquals("anotherPlayer", testProperty.getOwnerId()); // Owner ID should not change
+    }
+
+    @Test
+    void buyProperty_PropertyNotFound_FailsPreCheck() {
+        testPlayer.setMoney(PURCHASE_PRICE + 50);
+        when(propertyService.getHouseablePropertyById(PROPERTY_ID)).thenReturn(null);
+        // Ensure other lookups also return null/empty
+        when(propertyService.getTrainStations()).thenReturn(Collections.emptyList());
+        when(propertyService.getUtilities()).thenReturn(Collections.emptyList());
+
+
+        boolean result = propertyTransactionService.buyProperty(testPlayer, PROPERTY_ID);
+
+        assertFalse(result);
+        assertEquals(PURCHASE_PRICE + 50, testPlayer.getMoney()); // Money should not change
+    }
+
+    @Test
+    void findPropertyById_FindsHouseableProperty() {
+        when(propertyService.getHouseablePropertyById(PROPERTY_ID)).thenReturn(testProperty);
+
+        BaseProperty found = propertyTransactionService.findPropertyById(PROPERTY_ID);
+
+        assertNotNull(found);
+        assertEquals(PROPERTY_ID, found.getId());
+        verify(propertyService).getHouseablePropertyById(PROPERTY_ID);
+        verify(propertyService, never()).getTrainStations(); // Should not be called if found earlier
+        verify(propertyService, never()).getUtilities();     // Should not be called if found earlier
+    }
+
+    // Add similar tests for finding TrainStations and Utilities if needed
+    // Add test case where findPropertyById finds nothing (covered by PropertyNotFound tests above)
+
+}

--- a/src/test/java/at/aau/serg/monopoly/websoket/PropertyTransactionServiceTest.java
+++ b/src/test/java/at/aau/serg/monopoly/websoket/PropertyTransactionServiceTest.java
@@ -13,7 +13,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class) // Initialize Mockito


### PR DESCRIPTION
Dieser PR fügt die Kauf-Logik für Spielfelder (Properties) hinzu. 
Dabei wird sichergestellt, dass:
das Feld unbesitzt ist,
der Spieler genug Geld hat,
und der Kauf korrekt abgewickelt wird (Geld abziehen, Besitzer setzen).
Zusätzlich enthält der PR Unit-Tests für wichtigen Szenarien:
Kauf möglich / nicht möglich (z.B. zu wenig Geld, Feld schon besetzt),
erfolgreiche und fehlgeschlagene Käufe.
