### PR TITLE
Rolling the dices updates the Game State (and a bug is now fixed)

### DIFF
--- a/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
@@ -90,6 +90,7 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
         sessions.remove(session);
         broadcastMessage("Player left: " + session.getId() + " (Total: " + sessions.size() + ")");
         System.out.println("Player disconnected: " + session.getId());
+        game.removePlayer(session.getId());
     }
 
     private void broadcastMessage(String message) {

--- a/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
@@ -59,6 +59,11 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
                 DiceRollMessage drm = new DiceRollMessage(playerId, roll);
                 String json = objectMapper.writeValueAsString(drm);
                 broadcastMessage(json);
+
+                // Update Position and broadcast Game-State:
+                game.updatePlayerPosition(roll, playerId);
+                broadcastGameState();
+
             } else if (payload.startsWith("UPDATE_MONEY:")) {
                 try {
                     int amount = Integer.parseInt(payload.substring("UPDATE_MONEY:".length()));

--- a/src/main/java/model/Game.java
+++ b/src/main/java/model/Game.java
@@ -20,6 +20,10 @@ public class Game {
         players.add(new Player(id, name));
     }
 
+    public void removePlayer(String id) {
+        players.removeIf(player -> player.getId().equals(id));
+    }
+
     public void updatePlayerMoney(String playerId, int amount) {
         for (Player player : players) {
             if (player.getId().equals(playerId)) {

--- a/src/main/java/model/Game.java
+++ b/src/main/java/model/Game.java
@@ -44,7 +44,7 @@ public class Game {
     public List<PlayerInfo> getPlayerInfo() {
         List<PlayerInfo> info = new ArrayList<>();
         for (Player player : players) {
-            info.add(new PlayerInfo(player.getId(), player.getName(), player.getMoney()));
+            info.add(new PlayerInfo(player.getId(), player.getName(), player.getMoney(), player.getPosition()));
         }
         return info;
     }
@@ -59,4 +59,26 @@ public class Game {
                       .filter(player -> player.getId().equals(id))
                       .findFirst();
     }
+
+    /**
+     *
+     * @param roll The result of roll dice.
+     * @param id The ID of the player to find.
+     * @return If the player passes the Start field the method returns true, otherwise false.
+     */
+    public boolean updatePlayerPosition(int roll, String id){
+        for (Player player : players) {
+            if (player.getId().equals(id)) {
+                int oldPos = player.getPosition();
+                int newPos = (oldPos + roll) % 40;   // ensures 0–39
+                player.setPosition(newPos);
+
+                if (oldPos + roll >= 40) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
 }

--- a/src/main/java/model/Player.java
+++ b/src/main/java/model/Player.java
@@ -7,6 +7,7 @@ public class Player {
     private String name;
     private int money;
     private static final int STARTING_MONEY = 1500; // Standard Monopoly starting money
+    private int position = 0; // Starting position
 
     public Player(String id, String name) {
         this.id = id;

--- a/src/main/java/model/PlayerInfo.java
+++ b/src/main/java/model/PlayerInfo.java
@@ -11,4 +11,5 @@ public class PlayerInfo {
     private String id;
     private String name;
     private int money;
+    private int position;
 }

--- a/src/test/java/model/GameTest.java
+++ b/src/test/java/model/GameTest.java
@@ -1,8 +1,11 @@
 package model;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 class GameTest {
     private Game game;
@@ -88,5 +91,55 @@ class GameTest {
         // Test non-existent player ID (should not throw exception)
         game.updatePlayerMoney("999", 100);
         assertThat(game.getPlayers()).hasSize(2); // Should still have 2 players
+    }
+
+    @Test
+    void testRemovePlayerWorks(){
+        game.addPlayer("1", "Player 1");
+        game.addPlayer("2", "Player 2");
+        game.removePlayer("1");
+        assertThat(game.getPlayers()).hasSize(1);
+        assertThat(game.getPlayers().get(0).getName()).isEqualTo("Player 2");
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12})
+    void testUpdatePlayerPositionUpdatesCorrectPlayer(int turn) {
+        game.addPlayer("1", "Player 1");
+        game.addPlayer("2", "Player 2");
+
+        game.updatePlayerPosition(turn, "1");
+        assertEquals(turn, game.getPlayerById("1").get().getPosition());
+        assertEquals(0, game.getPlayerById("2").get().getPosition());
+    }
+
+    @Test
+    void testUpdatePlayerPositionReturnsCorrectBoolean(){
+        game.addPlayer("1", "Player 1");
+        boolean returnValue = game.updatePlayerPosition(25, "1");
+        assertFalse(returnValue);
+        returnValue = game.updatePlayerPosition(14, "1");
+        assertFalse(returnValue);
+        returnValue = game.updatePlayerPosition(1, "1");
+        assertTrue(returnValue);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {39, 40, 41, 60, 79, 80, 81, 500})
+    void testUpdatePlayerPositionValueCannotBeGreaterThanFourty(int roll){
+        game.addPlayer("1", "Player 1");
+        game.updatePlayerPosition(roll, "1");
+        assertThat(game.getPlayerById("1").get().getPosition()).isLessThan(40);
+    }
+
+    @Test
+    void testUpdatePlayerPositionHandlesOverflowCorrectly(){
+        game.addPlayer("1", "Player 1");
+        game.updatePlayerPosition(39, "1");
+        assertEquals(39, game.getPlayerById("1").get().getPosition());
+        game.updatePlayerPosition(1, "1");
+        assertEquals(0, game.getPlayerById("1").get().getPosition());
+        game.updatePlayerPosition(50, "1");
+        assertEquals(10, game.getPlayerById("1").get().getPosition());
     }
 }

--- a/src/test/java/model/PlayerTest.java
+++ b/src/test/java/model/PlayerTest.java
@@ -1,0 +1,13 @@
+package model;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PlayerTest {
+
+    @Test
+    public void testPositionIsInitializedToZero() {
+        Player player = new Player("12345", "TestPlayer");
+        assertEquals(0, player.getPosition());
+    }
+}


### PR DESCRIPTION
# Description
This PR fixes a bug where the game State was not broadcasted correctly after disconnecting and reconnecting to the server. Additionally the Game State now also includes the position of a Player on the Board.
___
# Changes
- After disconnecting a player is now also removed from the game, which fixes a bug
- The position is now broadcasted with the game state and can be updated by rolling the dice
- The starting position is set to 0 for each player joining the game
- Added tests for the Game and Player class