### PR TITLE
146 grundstuecke kaufen server

### DIFF
--- a/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
@@ -152,8 +152,13 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
                     sendMessageToSession(session, createJsonError("Failed to buy property due to server error."));
                 }
             } else {
-                logger.log(Level.WARNING, "Property purchase failed for player {0}, property {1} after canBuy check.", new Object[]{playerId, propertyId});
-                sendMessageToSession(session, createJsonError("Cannot buy property (insufficient funds or already owned)."));
+                if (!game.isPlayerTurn(playerId)) {
+                    logger.log(Level.WARNING, "Player {0} attempted to buy property {1} when it's not their turn", new Object[]{playerId, propertyId});
+                    sendMessageToSession(session, createJsonError("Cannot buy property - it's not your turn."));
+                } else {
+                    logger.log(Level.WARNING, "Property purchase failed for player {0}, property {1} after canBuy check.", new Object[]{playerId, propertyId});
+                    sendMessageToSession(session, createJsonError("Cannot buy property (insufficient funds or already owned)."));
+                }
             }
 
         } catch (NumberFormatException e) {

--- a/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
@@ -1,6 +1,5 @@
 package at.aau.serg.monopoly.websoket;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import data.DiceRollMessage;
 import lombok.NonNull;

--- a/src/main/java/model/Game.java
+++ b/src/main/java/model/Game.java
@@ -60,8 +60,20 @@ public class Game {
      */
     public Optional<Player> getPlayerById(String id) {
         return players.stream()
-                      .filter(player -> player.getId().equals(id))
-                      .findFirst();
+                .filter(player -> player.getId().equals(id))
+                .findFirst();
+    }
+
+    /**
+     * Checks if it's the specified player's turn
+     * @param playerId The ID of the player to check
+     * @return true if it's the player's turn, false otherwise
+     */
+    public boolean isPlayerTurn(String playerId) {
+        if (players.isEmpty() || currentPlayerIndex >= players.size()) {
+            return false;
+        }
+        return players.get(currentPlayerIndex).getId().equals(playerId);
     }
 
     /**

--- a/src/test/java/at/aau/serg/monopoly/websoket/GameWebSocketHandlerTest.java
+++ b/src/test/java/at/aau/serg/monopoly/websoket/GameWebSocketHandlerTest.java
@@ -1,0 +1,88 @@
+package at.aau.serg.monopoly.websoket;
+
+import model.Game;
+import model.Player;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class GameWebSocketHandlerTest {
+
+    private GameWebSocketHandler handler;
+    
+    @Mock
+    private WebSocketSession session;
+    
+    @Mock
+    private Game game;
+    
+    @Mock
+    private PropertyTransactionService propertyTransactionService;
+    
+    @Mock
+    private Player player;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        handler = new GameWebSocketHandler();
+        // Use reflection to set the mocked game and propertyTransactionService
+        try {
+            var gameField = GameWebSocketHandler.class.getDeclaredField("game");
+            gameField.setAccessible(true);
+            gameField.set(handler, game);
+            
+            var propertyServiceField = GameWebSocketHandler.class.getDeclaredField("propertyTransactionService");
+            propertyServiceField.setAccessible(true);
+            propertyServiceField.set(handler, propertyTransactionService);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set up test", e);
+        }
+    }
+
+    @Test
+    void givenNotPlayerTurn_whenAttemptingToBuyProperty_thenShouldSendNotYourTurnError() throws Exception {
+        // Arrange
+        String playerId = "player1";
+        int propertyId = 1;
+        when(session.getId()).thenReturn(playerId);
+        when(session.isOpen()).thenReturn(true);
+        when(game.getPlayerById(playerId)).thenReturn(Optional.of(player));
+        when(game.isPlayerTurn(playerId)).thenReturn(false);
+        when(propertyTransactionService.canBuyProperty(any(), anyInt())).thenReturn(false);
+
+        // Act
+        handler.handleTextMessage(session, new TextMessage("BUY_PROPERTY:" + propertyId));
+
+        // Assert
+        verify(session).sendMessage(argThat((TextMessage message) -> 
+            message.getPayload().contains("Cannot buy property - it's not your turn")));
+    }
+
+    @Test
+    void givenPlayerTurnButCannotBuy_whenAttemptingToBuyProperty_thenShouldSendCannotBuyError() throws Exception {
+        // Arrange
+        String playerId = "player1";
+        int propertyId = 1;
+        when(session.getId()).thenReturn(playerId);
+        when(session.isOpen()).thenReturn(true);
+        when(game.getPlayerById(playerId)).thenReturn(Optional.of(player));
+        when(game.isPlayerTurn(playerId)).thenReturn(true);
+        when(propertyTransactionService.canBuyProperty(any(), anyInt())).thenReturn(false);
+
+        // Act
+        handler.handleTextMessage(session, new TextMessage("BUY_PROPERTY:" + propertyId));
+
+        // Assert
+        verify(session).sendMessage(argThat((TextMessage message) -> 
+            message.getPayload().contains("Cannot buy property (insufficient funds or already owned)")));
+    }
+} 

--- a/src/test/java/model/GameTest.java
+++ b/src/test/java/model/GameTest.java
@@ -7,12 +7,18 @@ import org.junit.jupiter.params.provider.ValueSource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.lang.reflect.Field;
+
 class GameTest {
     private Game game;
+    private Player player1;
+    private Player player2;
 
     @BeforeEach
     void setUp() {
         game = new Game();
+        player1 = new Player("player1", "Player 1");
+        player2 = new Player("player2", "Player 2");
     }
 
     @Test
@@ -141,5 +147,48 @@ class GameTest {
         assertEquals(0, game.getPlayerById("1").get().getPosition());
         game.updatePlayerPosition(50, "1");
         assertEquals(10, game.getPlayerById("1").get().getPosition());
+    }
+
+    @Test
+    void givenEmptyPlayersList_whenCheckingPlayerTurn_thenShouldReturnFalse() {
+        // Arrange
+        // Game is already empty from setUp
+
+        // Act & Assert
+        assertFalse(game.isPlayerTurn("anyPlayerId"));
+    }
+
+    @Test
+    void givenCurrentPlayer_whenCheckingPlayerTurn_thenShouldReturnTrue() {
+        // Arrange
+        game.addPlayer(player1.getId(), player1.getName());
+        game.addPlayer(player2.getId(), player2.getName());
+
+        // Act & Assert
+        assertTrue(game.isPlayerTurn(player1.getId()));
+    }
+
+    @Test
+    void givenNonCurrentPlayer_whenCheckingPlayerTurn_thenShouldReturnFalse() {
+        // Arrange
+        game.addPlayer(player1.getId(), player1.getName());
+        game.addPlayer(player2.getId(), player2.getName());
+
+        // Act & Assert
+        assertFalse(game.isPlayerTurn(player2.getId()));
+    }
+
+    @Test
+    void givenInvalidCurrentPlayerIndex_whenCheckingPlayerTurn_thenShouldReturnFalse() throws Exception {
+        // Arrange
+        game.addPlayer(player1.getId(), player1.getName());
+        
+        // Use reflection to set an invalid currentPlayerIndex
+        Field currentPlayerIndexField = Game.class.getDeclaredField("currentPlayerIndex");
+        currentPlayerIndexField.setAccessible(true);
+        currentPlayerIndexField.set(game, 999); // Set to an index way beyond the players list size
+
+        // Act & Assert
+        assertFalse(game.isPlayerTurn(player1.getId()));
     }
 }


### PR DESCRIPTION
In diesem PR:

Fehlerbehandlung fürs Kaufen von Grundstücken ergänzt:
Spieler nicht am Zug → Fehlermeldung.
Spieler am Zug, aber kann nicht kaufen → Fehlermeldung.
Tests für beide Fälle im WebSocket-Handler geschrieben.
isPlayerTurn im Game getestet (verschiedene Szenarien inkl. leerer Liste & ungültigem Index).