### PR TITLE
Feature/end turn button&tests

### DIFF
--- a/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
@@ -171,11 +171,7 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
                 }
 
                 int roll = diceManager.rollDices();
-                if (roll == 12) {
-                    player.setHasRolledThisTurn(false);
-                } else {
-                    player.setHasRolledThisTurn(true);
-                }
+                player.setHasRolledThisTurn(roll != 12);
                 logger.log(Level.INFO, "Player {0} rolled {1}", new Object[]{userId, roll});
 
                 DiceRollMessage drm = new DiceRollMessage(userId, roll);
@@ -205,7 +201,7 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
 
                 broadcastGameState();
 
-            } else if (payload.equals("NEXT_TURN")) {
+            } else if ("NEXT_TURN".equals(payload)) {
                     logger.info("Received NEXT_TURN from " + userId);
 
                     if (!game.isPlayerTurn(userId)) {

--- a/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
@@ -166,7 +166,11 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
                 }
 
                 int roll = diceManager.rollDices();
-                player.setHasRolledThisTurn(true);
+                if (roll == 12) {
+                    player.setHasRolledThisTurn(false);
+                } else {
+                    player.setHasRolledThisTurn(true);
+                }
                 logger.log(Level.INFO, "Player {0} rolled {1}", new Object[]{userId, roll});
 
                 DiceRollMessage drm = new DiceRollMessage(userId, roll);

--- a/src/main/java/model/Game.java
+++ b/src/main/java/model/Game.java
@@ -55,6 +55,7 @@ public class Game {
 
     public void nextPlayer() {
         currentPlayerIndex = (currentPlayerIndex + 1) % players.size();
+        players.get(currentPlayerIndex).setHasRolledThisTurn(false);
     }
 
     public List<PlayerInfo> getPlayerInfo() {

--- a/src/main/java/model/Player.java
+++ b/src/main/java/model/Player.java
@@ -1,5 +1,6 @@
 package model;
 import lombok.Data;
+import lombok.Setter;
 
 @Data
 public class Player {
@@ -8,6 +9,8 @@ public class Player {
     private int money;
     private static final int STARTING_MONEY = 1500; // Standard Monopoly starting money
     private int position = 0; // Starting position
+    @Setter
+    private boolean hasRolledThisTurn = false;
 
     public Player(String id, String name) {
         this.id = id;
@@ -21,5 +24,9 @@ public class Player {
 
     public void subtractMoney(int amount) {
         this.money -= amount;
+    }
+
+    public boolean hasRolledThisTurn() {
+        return hasRolledThisTurn;
     }
 }

--- a/src/test/java/at/aau/serg/monopoly/websoket/GameWebSocketHandlerDiceTest.java
+++ b/src/test/java/at/aau/serg/monopoly/websoket/GameWebSocketHandlerDiceTest.java
@@ -367,7 +367,7 @@ class GameWebSocketHandlerDiceTest {
         // u2 versucht Zug zu enden obwohl u1 dran ist
         handler.handleTextMessage(s2, new TextMessage("NEXT_TURN"));
 
-        verify(s2).sendMessage(msgCaptor.capture());
+        verify(s2, atLeastOnce()).sendMessage(msgCaptor.capture());
         String payload = msgCaptor.getValue().getPayload();
         assertTrue(payload.contains("Not your turn!"));
     }

--- a/src/test/java/at/aau/serg/monopoly/websoket/GameWebSocketHandlerDiceTest.java
+++ b/src/test/java/at/aau/serg/monopoly/websoket/GameWebSocketHandlerDiceTest.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.*;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import model.DiceManagerInterface;
+import model.Game;
+import model.Player;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.*;
@@ -258,5 +260,147 @@ class GameWebSocketHandlerDiceTest {
         verify(session).sendMessage(msgCaptor.capture());
         TextMessage errorMsg = msgCaptor.getValue();
         assertTrue(errorMsg.getPayload().contains("Invalid manual roll format"));
+    }
+    @Test
+    void testNextTurnReturnsErrorIfNotYourTurn() throws Exception {
+        handler.afterConnectionEstablished(session);
+
+        String initJson = mapper.createObjectNode()
+                .put("type", "INIT")
+                .put("userId", "u1")
+                .put("name", "Alice")
+                .toString();
+        handler.handleTextMessage(session, new TextMessage(initJson));
+
+        // Manipuliert Spiellogik, damit Spieler nicht dran ist
+        Game spyGame = spy(new Game());
+        spyGame.addPlayer("u1", "Alice");
+        ReflectionTestUtils.setField(handler, "game", spyGame);
+
+        doReturn(false).when(spyGame).isPlayerTurn("u1");
+
+        clearInvocations(session);
+
+        handler.handleTextMessage(session, new TextMessage("NEXT_TURN"));
+
+        verify(session).sendMessage(msgCaptor.capture());
+        String msg = msgCaptor.getValue().getPayload();
+        assertTrue(msg.contains("Not your turn"));
+    }
+
+
+    @Test
+    void testNextTurnAdvancesPlayerIfValid() throws Exception {
+        handler.afterConnectionEstablished(session);
+
+        String initJson = mapper.createObjectNode()
+                .put("type", "INIT")
+                .put("userId", "u1")
+                .put("name", "Alice")
+                .toString();
+        handler.handleTextMessage(session, new TextMessage(initJson));
+
+        Game spyGame = spy(new Game());
+        spyGame.addPlayer("u1", "Alice");
+        ReflectionTestUtils.setField(handler, "game", spyGame);
+
+        doReturn(true).when(spyGame).isPlayerTurn("u1");
+
+        clearInvocations(session);
+
+        handler.handleTextMessage(session, new TextMessage("NEXT_TURN"));
+
+        verify(spyGame).nextPlayer();
+    }
+
+
+    @Test
+    void testRollTwelveAllowsSecondRoll() throws Exception {
+        handler.afterConnectionEstablished(session);
+
+        // INIT
+        String initJson = mapper.createObjectNode()
+                .put("type", "INIT")
+                .put("userId", "u1")
+                .put("name", "Alice")
+                .toString();
+        handler.handleTextMessage(session, new TextMessage(initJson));
+
+        // Würfeln: zuerst 12, dann z.B. 4
+        DiceManagerInterface mockDice = mock(DiceManagerInterface.class);
+        when(mockDice.rollDices()).thenReturn(12).thenReturn(4); // zweimal würfeln erlaubt
+        ReflectionTestUtils.setField(handler, "diceManager", mockDice);
+
+        clearInvocations(session);
+
+        // Roll #1 = 12
+        handler.handleTextMessage(session, new TextMessage("Roll"));
+
+        // Roll #2 = 4 (immer noch erlaubt)
+        handler.handleTextMessage(session, new TextMessage("Roll"));
+
+        // Check ob beide Rolls gesendet wurden
+        verify(session, atLeast(2)).sendMessage(msgCaptor.capture());
+        List<TextMessage> sent = msgCaptor.getAllValues();
+
+        long diceRolls = sent.stream().filter(m -> m.getPayload().contains("DICE_ROLL")).count();
+        assertEquals(2, diceRolls); // zwei gültige Würfe erlaubt
+    }
+
+    @Test
+    void testNextTurnFromWrongPlayer_returnsError() throws Exception {
+        WebSocketSession s1 = mock(WebSocketSession.class);
+        WebSocketSession s2 = mock(WebSocketSession.class);
+        when(s1.getId()).thenReturn("s1");
+        when(s2.getId()).thenReturn("s2");
+        when(s1.isOpen()).thenReturn(true);
+        when(s2.isOpen()).thenReturn(true);
+
+        handler.afterConnectionEstablished(s1);
+        handler.afterConnectionEstablished(s2);
+
+        handler.handleTextMessage(s1, new TextMessage(mapper.createObjectNode()
+                .put("type", "INIT").put("userId", "u1").put("name", "Alice").toString()));
+        handler.handleTextMessage(s2, new TextMessage(mapper.createObjectNode()
+                .put("type", "INIT").put("userId", "u2").put("name", "Bob").toString()));
+
+        // u2 versucht Zug zu enden obwohl u1 dran ist
+        handler.handleTextMessage(s2, new TextMessage("NEXT_TURN"));
+
+        verify(s2).sendMessage(msgCaptor.capture());
+        String payload = msgCaptor.getValue().getPayload();
+        assertTrue(payload.contains("Not your turn!"));
+    }
+
+    @Test
+    void testRollTwiceWithoutTwelveReturnsError() throws Exception {
+        handler.afterConnectionEstablished(session);
+
+        // INIT
+        String initJson = mapper.createObjectNode()
+                .put("type", "INIT")
+                .put("userId", "u1")
+                .put("name", "Alice")
+                .toString();
+        handler.handleTextMessage(session, new TextMessage(initJson));
+
+        // roll ≠ 12
+        DiceManagerInterface mockDice = mock(DiceManagerInterface.class);
+        when(mockDice.rollDices()).thenReturn(5);
+        ReflectionTestUtils.setField(handler, "diceManager", mockDice);
+
+        clearInvocations(session);
+
+        // roll 1
+        handler.handleTextMessage(session, new TextMessage("Roll"));
+
+        // roll 2 (ungültig)
+        clearInvocations(session);
+        handler.handleTextMessage(session, new TextMessage("Roll"));
+
+        // error
+        verify(session).sendMessage(msgCaptor.capture());
+        TextMessage errorMsg = msgCaptor.getValue();
+        assertTrue(errorMsg.getPayload().contains("already rolled"));
     }
 }

--- a/src/test/java/at/aau/serg/monopoly/websoket/GameWebSocketHandlerDiceTest.java
+++ b/src/test/java/at/aau/serg/monopoly/websoket/GameWebSocketHandlerDiceTest.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import model.DiceManagerInterface;
 import model.Game;
-import model.Player;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.*;
@@ -290,7 +289,7 @@ class GameWebSocketHandlerDiceTest {
 
 
     @Test
-    void testNextTurnAdvancesPlayerIfValid() throws Exception {
+    void testNextTurnAdvancesPlayerIfValid() {
         handler.afterConnectionEstablished(session);
 
         String initJson = mapper.createObjectNode()


### PR DESCRIPTION
Dieser PR implementiert ein manuelles Zugende, damit andere Funktionen korrekt im Frontend funktionieren.

Änderungen:

- Die Logik für das Ende eines Spielerzugs wurde implementiert.
- Ein Spieler muss nun aktiv "NEXT_TURN" senden, damit der nächste Spieler dran ist.
- Verschiedene Würfelfunktionen wurden angepasst
- Tests wurden erweitert (next_turn, würfeln)