### PR TITLE
26 server miete zahlen und kassieren

### DIFF
--- a/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
@@ -12,6 +12,7 @@ import model.DiceManager;
 import model.DiceManagerInterface;
 import model.Game;
 import model.Player;
+import model.properties.BaseProperty;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.*;
@@ -43,6 +44,12 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
     private CardDeckService cardDeckService;
     @Autowired
     private PropertyTransactionService propertyTransactionService;
+    @Autowired
+    private PropertyService propertyService;
+    @Autowired
+    private RentCollectionService rentCollectionService;
+    @Autowired
+    private RentCalculationService rentCalculationService;
 
     @Override
     public void afterConnectionEstablished(@NonNull WebSocketSession session) {
@@ -238,20 +245,7 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
 
                 // Check for tax fields and send appropriate messages
                 int position = player.getPosition();
-                if (position == 4) {  // Einkommensteuer
-                    game.updatePlayerMoney(userId, -200);  // Deduct money first
-                    TaxPaymentMessage taxMsg = new TaxPaymentMessage(userId, 200, "EINKOMMENSTEUER");
-                    String jsonTax = objectMapper.writeValueAsString(taxMsg);
-                    broadcastMessage(jsonTax);
-                } else if (position == 38) {  // Zusatzsteuer
-                    game.updatePlayerMoney(userId, -100);  // Deduct money first
-                    TaxPaymentMessage taxMsg = new TaxPaymentMessage(userId, 100, "ZUSATZSTEUER");
-                    String jsonTax = objectMapper.writeValueAsString(taxMsg);
-                    broadcastMessage(jsonTax);
-                }
-
-
-                broadcastGameState();
+                handlePlayerLanding(player, position);
 
             } else if ("NEXT_TURN".equals(payload)) {
                     logger.log(Level.INFO, "Received NEXT_TURN from {0}", userId);
@@ -449,6 +443,37 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
         } catch (Exception e) {
             logger.log(Level.SEVERE, "Error processing GIVE_UP message", e);
             sendMessageToSession(session, createJsonError("Error processing give up."));
+        }
+    }
+
+    private void handlePlayerLanding(Player player, int position) {
+        try {
+            // Check for tax squares
+            if (position == 4) {  // Einkommensteuer
+                game.updatePlayerMoney(player.getId(), -200);  // Deduct money first
+                TaxPaymentMessage taxMsg = new TaxPaymentMessage(player.getId(), 200, "EINKOMMENSTEUER");
+                String jsonTax = objectMapper.writeValueAsString(taxMsg);
+                broadcastMessage(jsonTax);
+            } else if (position == 38) {  // Zusatzsteuer
+                game.updatePlayerMoney(player.getId(), -100);  // Deduct money first
+                TaxPaymentMessage taxMsg = new TaxPaymentMessage(player.getId(), 100, "ZUSATZSTEUER");
+                String jsonTax = objectMapper.writeValueAsString(taxMsg);
+                broadcastMessage(jsonTax);
+            }
+
+            // Check for property and collect rent if applicable
+            BaseProperty property = propertyService.getPropertyByPosition(position);
+            if (property != null) {
+                boolean rentCollected = rentCollectionService.collectRent(player, property);
+                if (rentCollected) {
+                    String rentMsg = String.format("Player %s paid rent for %s", player.getName(), property.getName());
+                    broadcastMessage(rentMsg);
+                }
+            }
+
+            broadcastGameState();
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Error handling player landing: {0}", e.getMessage());
         }
     }
 }

--- a/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
@@ -7,6 +7,7 @@ import data.DiceRollMessage;
 import data.DrawnCardMessage;
 import data.PullCardMessage;
 import data.TaxPaymentMessage;
+import data.RentPaymentMessage;
 import lombok.NonNull;
 import model.DiceManager;
 import model.DiceManagerInterface;
@@ -466,8 +467,18 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
             if (property != null) {
                 boolean rentCollected = rentCollectionService.collectRent(player, property);
                 if (rentCollected) {
-                    String rentMsg = String.format("Player %s paid rent for %s", player.getName(), property.getName());
-                    broadcastMessage(rentMsg);
+                    // Create and broadcast rent payment message
+                    RentPaymentMessage rentMsg = new RentPaymentMessage(
+                        player.getId(),
+                        property.getOwnerId(),
+                        property.getId(),
+                        property.getName(),
+                        rentCalculationService.calculateRent(property, 
+                            propertyService.getPlayerById(property.getOwnerId()), 
+                            player)
+                    );
+                    String jsonRent = objectMapper.writeValueAsString(rentMsg);
+                    broadcastMessage(jsonRent);
                 }
             }
 

--- a/src/main/java/at/aau/serg/monopoly/websoket/PropertyService.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/PropertyService.java
@@ -1,21 +1,39 @@
 package at.aau.serg.monopoly.websoket;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Getter;
+import model.Game;
+import model.Player;
 import model.properties.HouseableProperty;
 import model.properties.TrainStation;
 import model.properties.Utility;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
 import jakarta.annotation.PostConstruct;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 @Service
 public class PropertyService {
 
+    private static final Logger logger = Logger.getLogger(PropertyService.class.getName());
+    private Game game;
+    @Getter
     private List<HouseableProperty> houseableProperties;
+    @Getter
     private List<TrainStation> trainStations;
+    @Getter
     private List<Utility> utilities;
+
+    public PropertyService() {
+        // Default constructor for cases where Game is not needed
+    }
+
+    public PropertyService(Game game) {
+        this.game = game;
+    }
 
     @PostConstruct
     public void init() throws RuntimeException {
@@ -33,21 +51,29 @@ public class PropertyService {
         }
     }
 
-    public List<HouseableProperty> getHouseableProperties() {
-        return houseableProperties;
-    }
-
-    public List<TrainStation> getTrainStations() {
-        return trainStations;
-    }
-
-    public List<Utility> getUtilities() {
-        return utilities;
-    }
-
     public HouseableProperty getHouseablePropertyById(int id) {
         return houseableProperties.stream()
                 .filter(property -> property.getId() == id)
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * Gets a player by their ID
+     * @param playerId The ID of the player to find
+     * @return The player if found, null otherwise
+     */
+    public Player getPlayerById(String playerId) {
+        if (playerId == null) {
+            logger.log(Level.WARNING, "Attempted to get player with null ID");
+            return null;
+        }
+        if (game == null) {
+            logger.log(Level.WARNING, "Game instance is null, cannot get player");
+            return null;
+        }
+        return game.getPlayers().stream()
+                .filter(player -> player.getId().equals(playerId))
                 .findFirst()
                 .orElse(null);
     }

--- a/src/main/java/at/aau/serg/monopoly/websoket/PropertyService.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/PropertyService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import model.Game;
 import model.Player;
+import model.properties.BaseProperty;
 import model.properties.HouseableProperty;
 import model.properties.TrainStation;
 import model.properties.Utility;
@@ -74,6 +75,39 @@ public class PropertyService {
         }
         return game.getPlayers().stream()
                 .filter(player -> player.getId().equals(playerId))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * Gets a property by its position on the board
+     * @param position The position to find the property at
+     * @return The property if found, null otherwise
+     */
+    public BaseProperty getPropertyByPosition(int position) {
+        // Check houseable properties
+        BaseProperty property = houseableProperties.stream()
+                .filter(p -> p.getPosition() == position)
+                .findFirst()
+                .orElse(null);
+        
+        if (property != null) {
+            return property;
+        }
+
+        // Check train stations
+        property = trainStations.stream()
+                .filter(p -> p.getPosition() == position)
+                .findFirst()
+                .orElse(null);
+        
+        if (property != null) {
+            return property;
+        }
+
+        // Check utilities
+        return utilities.stream()
+                .filter(p -> p.getPosition() == position)
                 .findFirst()
                 .orElse(null);
     }

--- a/src/main/java/at/aau/serg/monopoly/websoket/RentCalculationService.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/RentCalculationService.java
@@ -13,6 +13,7 @@ import java.util.logging.Logger;
 @Service
 public class RentCalculationService {
     private static final Logger logger = Logger.getLogger(RentCalculationService.class.getName());
+
     private final PropertyService propertyService;
 
     public RentCalculationService(PropertyService propertyService) {
@@ -20,7 +21,7 @@ public class RentCalculationService {
     }
 
     /**
-     * Calculates the rent amount for a property based on its type and owner's holdings
+     * Calculates the rent for a property based on its type and owner
      * @param property The property to calculate rent for
      * @param owner The owner of the property
      * @param renter The player who landed on the property
@@ -32,33 +33,11 @@ public class RentCalculationService {
             return 0;
         }
 
-        try {
-            if (property instanceof HouseableProperty) {
-                return calculateHouseablePropertyRent((HouseableProperty) property, owner);
-            } else if (property instanceof TrainStation) {
-                return calculateTrainStationRent((TrainStation) property, owner);
-            } else if (property instanceof Utility) {
-                return calculateUtilityRent((Utility) property, owner, renter);
-            }
-        } catch (Exception e) {
-            logger.log(Level.SEVERE, "Error calculating rent: " + e.getMessage());
+        // For now, just return base rent for houseable properties
+        if (property instanceof HouseableProperty) {
+            return ((HouseableProperty) property).getBaseRent();
         }
 
-        return 0;
-    }
-
-    private int calculateHouseablePropertyRent(HouseableProperty property, Player owner) {
-        // TODO: Implement houseable property rent calculation
-        return 0;
-    }
-
-    private int calculateTrainStationRent(TrainStation property, Player owner) {
-        // TODO: Implement train station rent calculation
-        return 0;
-    }
-
-    private int calculateUtilityRent(Utility property, Player owner, Player renter) {
-        // TODO: Implement utility rent calculation
         return 0;
     }
 } 

--- a/src/main/java/at/aau/serg/monopoly/websoket/RentCalculationService.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/RentCalculationService.java
@@ -1,0 +1,64 @@
+package at.aau.serg.monopoly.websoket;
+
+import model.Player;
+import model.properties.BaseProperty;
+import model.properties.HouseableProperty;
+import model.properties.TrainStation;
+import model.properties.Utility;
+import org.springframework.stereotype.Service;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Service
+public class RentCalculationService {
+    private static final Logger logger = Logger.getLogger(RentCalculationService.class.getName());
+    private final PropertyService propertyService;
+
+    public RentCalculationService(PropertyService propertyService) {
+        this.propertyService = propertyService;
+    }
+
+    /**
+     * Calculates the rent amount for a property based on its type and owner's holdings
+     * @param property The property to calculate rent for
+     * @param owner The owner of the property
+     * @param renter The player who landed on the property
+     * @return The calculated rent amount
+     */
+    public int calculateRent(BaseProperty property, Player owner, Player renter) {
+        if (property == null || owner == null || renter == null) {
+            logger.log(Level.WARNING, "Invalid parameters for rent calculation");
+            return 0;
+        }
+
+        try {
+            if (property instanceof HouseableProperty) {
+                return calculateHouseablePropertyRent((HouseableProperty) property, owner);
+            } else if (property instanceof TrainStation) {
+                return calculateTrainStationRent((TrainStation) property, owner);
+            } else if (property instanceof Utility) {
+                return calculateUtilityRent((Utility) property, owner, renter);
+            }
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Error calculating rent: " + e.getMessage());
+        }
+
+        return 0;
+    }
+
+    private int calculateHouseablePropertyRent(HouseableProperty property, Player owner) {
+        // TODO: Implement houseable property rent calculation
+        return 0;
+    }
+
+    private int calculateTrainStationRent(TrainStation property, Player owner) {
+        // TODO: Implement train station rent calculation
+        return 0;
+    }
+
+    private int calculateUtilityRent(Utility property, Player owner, Player renter) {
+        // TODO: Implement utility rent calculation
+        return 0;
+    }
+} 

--- a/src/main/java/at/aau/serg/monopoly/websoket/RentCollectionService.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/RentCollectionService.java
@@ -1,0 +1,89 @@
+package at.aau.serg.monopoly.websoket;
+
+import model.Player;
+import model.properties.BaseProperty;
+import org.springframework.stereotype.Service;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Service
+public class RentCollectionService {
+    private static final Logger logger = Logger.getLogger(RentCollectionService.class.getName());
+
+    private final PropertyService propertyService;
+    private final RentCalculationService rentCalculationService;
+
+    public RentCollectionService(PropertyService propertyService, RentCalculationService rentCalculationService) {
+        this.propertyService = propertyService;
+        this.rentCalculationService = rentCalculationService;
+    }
+
+    /**
+     * Validates if rent can be collected from a player
+     * @param renter The player who landed on the property
+     * @param property The property to collect rent for
+     * @return true if rent can be collected, false otherwise
+     */
+    private boolean canCollectRent(Player renter, BaseProperty property) {
+        if (renter == null || property == null) {
+            logger.log(Level.WARNING, "Invalid parameters for rent collection validation");
+            return false;
+        }
+
+        // Check if property is owned by another player
+        if (property.getOwnerId() == null || property.getOwnerId().equals(renter.getId())) {
+            logger.log(Level.INFO, "Property {0} is not owned by another player", property.getName());
+            return false;
+        }
+
+        // Check if property is mortgaged
+        if (property.isMortgaged()) {
+            logger.log(Level.INFO, "Property {0} is mortgaged, no rent can be collected", property.getName());
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Collects rent from a player who landed on a property
+     * @param renter The player who landed on the property
+     * @param property The property to collect rent for
+     * @return true if rent was collected successfully, false otherwise
+     */
+    public boolean collectRent(Player renter, BaseProperty property) {
+        if (!canCollectRent(renter, property)) {
+            return false;
+        }
+
+        // Get the property owner
+        Player owner = propertyService.getPlayerById(property.getOwnerId());
+        if (owner == null) {
+            logger.log(Level.WARNING, "Property owner not found for property {0}", property.getName());
+            return false;
+        }
+
+        // Calculate rent amount
+        int rentAmount = rentCalculationService.calculateRent(property, owner, renter);
+        
+        // Check if renter has enough money
+        if (renter.getMoney() < rentAmount) {
+            logger.log(Level.INFO, "Player {0} has insufficient funds to pay rent", renter.getId());
+            return false;
+        }
+
+        // Process rent payment
+        try {
+            renter.subtractMoney(rentAmount);
+            owner.addMoney(rentAmount);
+            
+            logger.log(Level.INFO, "Rent of {0} collected from player {1} for property {2}", 
+                new Object[]{rentAmount, renter.getId(), property.getName()});
+            return true;
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Error processing rent payment: {0}", e.getMessage());
+            return false;
+        }
+    }
+} 

--- a/src/main/java/at/aau/serg/monopoly/websoket/RentCollectionService.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/RentCollectionService.java
@@ -25,7 +25,7 @@ public class RentCollectionService {
      * @param property The property to collect rent for
      * @return true if rent can be collected, false otherwise
      */
-    private boolean canCollectRent(Player renter, BaseProperty property) {
+    boolean canCollectRent(Player renter, BaseProperty property) {
         if (renter == null || property == null) {
             logger.log(Level.WARNING, "Invalid parameters for rent collection validation");
             return false;

--- a/src/main/java/data/RentPaymentMessage.java
+++ b/src/main/java/data/RentPaymentMessage.java
@@ -1,0 +1,21 @@
+package data;
+
+import lombok.Data;
+
+@Data
+public class RentPaymentMessage {
+    private String type = "RENT_PAYMENT";
+    private String renterId;
+    private String ownerId;
+    private int propertyId;
+    private String propertyName;
+    private int amount;
+
+    public RentPaymentMessage(String renterId, String ownerId, int propertyId, String propertyName, int amount) {
+        this.renterId = renterId;
+        this.ownerId = ownerId;
+        this.propertyId = propertyId;
+        this.propertyName = propertyName;
+        this.amount = amount;
+    }
+} 

--- a/src/test/java/at/aau/serg/monopoly/websoket/GameWebSocketHandlerDiceTest.java
+++ b/src/test/java/at/aau/serg/monopoly/websoket/GameWebSocketHandlerDiceTest.java
@@ -20,6 +20,11 @@ class GameWebSocketHandlerDiceTest {
 
     @Mock WebSocketSession session;
     @Mock PropertyTransactionService propertyTransactionService;
+    @Mock PropertyService propertyService;
+    @Mock RentCollectionService rentCollectionService;
+    @Mock RentCalculationService rentCalculationService;
+    @Mock GameHistoryService gameHistoryService;
+    @Mock CardDeckService cardDeckService;
 
     @Captor ArgumentCaptor<TextMessage> msgCaptor;
 
@@ -32,6 +37,11 @@ class GameWebSocketHandlerDiceTest {
         handler = new GameWebSocketHandler();
 
         ReflectionTestUtils.setField(handler, "propertyTransactionService", propertyTransactionService);
+        ReflectionTestUtils.setField(handler, "propertyService", propertyService);
+        ReflectionTestUtils.setField(handler, "rentCollectionService", rentCollectionService);
+        ReflectionTestUtils.setField(handler, "rentCalculationService", rentCalculationService);
+        ReflectionTestUtils.setField(handler, "gameHistoryService", gameHistoryService);
+        ReflectionTestUtils.setField(handler, "cardDeckService", cardDeckService);
 
         when(session.getId()).thenReturn("session-1");
         when(session.isOpen()).thenReturn(true);
@@ -149,6 +159,11 @@ class GameWebSocketHandlerDiceTest {
 
         handler = new GameWebSocketHandler();
         ReflectionTestUtils.setField(handler, "propertyTransactionService", propertyTransactionService);
+        ReflectionTestUtils.setField(handler, "propertyService", propertyService);
+        ReflectionTestUtils.setField(handler, "rentCollectionService", rentCollectionService);
+        ReflectionTestUtils.setField(handler, "rentCalculationService", rentCalculationService);
+        ReflectionTestUtils.setField(handler, "gameHistoryService", gameHistoryService);
+        ReflectionTestUtils.setField(handler, "cardDeckService", cardDeckService);
 
         handler.afterConnectionEstablished(s1);
         handler.afterConnectionEstablished(s2);

--- a/src/test/java/at/aau/serg/monopoly/websoket/PropertyServiceTest.java
+++ b/src/test/java/at/aau/serg/monopoly/websoket/PropertyServiceTest.java
@@ -4,20 +4,40 @@ import model.properties.TrainStation;
 import model.properties.Utility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
+import model.Game;
+import model.Player;
+import java.util.Arrays;
+import java.util.Collections;
+
+@ExtendWith(MockitoExtension.class)
 public class PropertyServiceTest {
 
+    @Mock
+    private Game game;
+
+    @InjectMocks
     private PropertyService propertyService;
+
+    private Player player1;
+    private Player player2;
 
     @BeforeEach
     void setUp() {
-        propertyService = new PropertyService();
+        propertyService = new PropertyService(game);
         propertyService.init();
+        player1 = new Player("player1", "Player One");
+        player2 = new Player("player2", "Player Two");
     }
 
     @Test
@@ -70,4 +90,62 @@ public class PropertyServiceTest {
         assertTrue(exception.getMessage().contains("Failed to initialize property data"));
     }
 
+    @Test
+    void getPlayerById_WithValidId_ReturnsPlayer() {
+        // Arrange
+        when(game.getPlayers()).thenReturn(Arrays.asList(player1, player2));
+
+        // Act
+        Player result = propertyService.getPlayerById("player1");
+
+        // Assert
+        assertNotNull(result, "Should return player when ID exists");
+        assertEquals("player1", result.getId(), "Should return correct player");
+    }
+
+    @Test
+    void getPlayerById_WithNonExistentId_ReturnsNull() {
+        // Arrange
+        when(game.getPlayers()).thenReturn(Arrays.asList(player1, player2));
+
+        // Act
+        Player result = propertyService.getPlayerById("nonexistent");
+
+        // Assert
+        assertNull(result, "Should return null when ID doesn't exist");
+    }
+
+    @Test
+    void getPlayerById_WithNullId_ReturnsNull() {
+        // Act
+        Player result = propertyService.getPlayerById(null);
+
+        // Assert
+        assertNull(result, "Should return null when ID is null");
+        verify(game, never()).getPlayers();
+    }
+
+    @Test
+    void getPlayerById_WithNullGame_ReturnsNull() {
+        // Arrange
+        PropertyService service = new PropertyService(null);
+
+        // Act
+        Player result = service.getPlayerById("player1");
+
+        // Assert
+        assertNull(result, "Should return null when game is null");
+    }
+
+    @Test
+    void getPlayerById_WithEmptyPlayersList_ReturnsNull() {
+        // Arrange
+        when(game.getPlayers()).thenReturn(Collections.emptyList());
+
+        // Act
+        Player result = propertyService.getPlayerById("player1");
+
+        // Assert
+        assertNull(result, "Should return null when players list is empty");
+    }
 }

--- a/src/test/java/at/aau/serg/monopoly/websoket/PropertyServiceTest.java
+++ b/src/test/java/at/aau/serg/monopoly/websoket/PropertyServiceTest.java
@@ -1,4 +1,7 @@
 package at.aau.serg.monopoly.websoket;
+import model.Game;
+import model.Player;
+import model.properties.BaseProperty;
 import model.properties.HouseableProperty;
 import model.properties.TrainStation;
 import model.properties.Utility;
@@ -15,8 +18,6 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import model.Game;
-import model.Player;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -147,5 +148,147 @@ public class PropertyServiceTest {
 
         // Assert
         assertNull(result, "Should return null when players list is empty");
+    }
+
+    @Test
+    void getPropertyByPosition_WithHouseableProperty_ReturnsProperty() {
+        // Arrange
+        HouseableProperty houseableProperty = new HouseableProperty(
+            1,                // id
+            null,            // ownerId
+            "Test Street",    // name
+            100,             // purchasePrice
+            10,              // baseRent
+            50,              // rent1House
+            150,             // rent2Houses
+            450,             // rent3Houses
+            625,             // rent4Houses
+            750,             // rentHotel
+            50,              // housePrice
+            50,              // hotelPrice
+            50,              // mortgageValue
+            false,           // isMortgaged
+            "test_image",    // image
+            5                // position
+        );
+        propertyService.getHouseableProperties().add(houseableProperty);
+
+        // Act
+        BaseProperty result = propertyService.getPropertyByPosition(5);
+
+        // Assert
+        assertNotNull(result, "Should find houseable property at position 5");
+        assertTrue(result instanceof HouseableProperty, "Should return HouseableProperty");
+        assertEquals(5, result.getPosition(), "Should return property at correct position");
+    }
+
+    @Test
+    void getPropertyByPosition_WithTrainStation_ReturnsProperty() {
+        // Arrange
+        TrainStation trainStation = new TrainStation(
+            1,                // id
+            null,            // ownerId
+            "Test Station",   // name
+            200,             // purchasePrice
+            25,              // baseRent
+            50,              // rent2Stations
+            100,             // rent3Stations
+            200,             // rent4Stations
+            100,             // mortgageValue
+            false,           // isMortgaged
+            "test_image",    // image
+            15               // position
+        );
+        propertyService.getTrainStations().add(trainStation);
+
+        // Act
+        BaseProperty result = propertyService.getPropertyByPosition(15);
+
+        // Assert
+        assertNotNull(result, "Should find train station at position 15");
+        assertTrue(result instanceof TrainStation, "Should return TrainStation");
+        assertEquals(15, result.getPosition(), "Should return property at correct position");
+    }
+
+    @Test
+    void getPropertyByPosition_WithUtility_ReturnsProperty() {
+        // Arrange
+        Utility utility = new Utility(
+            1,                // id
+            null,            // ownerId
+            "Test Utility",   // name
+            150,             // purchasePrice
+            4,               // rentOneUtilityMultiplier
+            10,              // rentTwoUtilitiesMultiplier
+            75,              // mortgageValue
+            false,           // isMortgaged
+            "test_image",    // image
+            28               // position
+        );
+        propertyService.getUtilities().add(utility);
+
+        // Act
+        BaseProperty result = propertyService.getPropertyByPosition(28);
+
+        // Assert
+        assertNotNull(result, "Should find utility at position 28");
+        assertTrue(result instanceof Utility, "Should return Utility");
+        assertEquals(28, result.getPosition(), "Should return property at correct position");
+    }
+
+    @Test
+    void getPropertyByPosition_WithNonExistentPosition_ReturnsNull() {
+        // Act
+        BaseProperty result = propertyService.getPropertyByPosition(999);
+
+        // Assert
+        assertNull(result, "Should return null for non-existent position");
+    }
+
+    @Test
+    void getPropertyByPosition_WithMultiplePropertiesAtSamePosition_ReturnsFirstFound() {
+        // Arrange
+        HouseableProperty houseableProperty = new HouseableProperty(
+            1,                // id
+            null,            // ownerId
+            "Test Street",    // name
+            100,             // purchasePrice
+            10,              // baseRent
+            50,              // rent1House
+            150,             // rent2Houses
+            450,             // rent3Houses
+            625,             // rent4Houses
+            750,             // rentHotel
+            50,              // housePrice
+            50,              // hotelPrice
+            50,              // mortgageValue
+            false,           // isMortgaged
+            "test_image",    // image
+            5                // position
+        );
+        TrainStation trainStation = new TrainStation(
+            2,                // id
+            null,            // ownerId
+            "Test Station",   // name
+            200,             // purchasePrice
+            25,              // baseRent
+            50,              // rent2Stations
+            100,             // rent3Stations
+            200,             // rent4Stations
+            100,             // mortgageValue
+            false,           // isMortgaged
+            "test_image",    // image
+            5                // position
+        );
+        propertyService.getHouseableProperties().add(houseableProperty);
+        propertyService.getTrainStations().add(trainStation);
+
+        // Act
+        BaseProperty result = propertyService.getPropertyByPosition(5);
+
+        // Assert
+        assertNotNull(result, "Should find property at position 5");
+        assertTrue(result instanceof HouseableProperty, "Should return first found property (HouseableProperty)");
+        assertEquals(5, result.getPosition(), "Should return property at correct position");
     }
 }

--- a/src/test/java/at/aau/serg/monopoly/websoket/RentCalculationServiceTest.java
+++ b/src/test/java/at/aau/serg/monopoly/websoket/RentCalculationServiceTest.java
@@ -1,0 +1,90 @@
+package at.aau.serg.monopoly.websoket;
+
+import model.Player;
+import model.properties.BaseProperty;
+import model.properties.HouseableProperty;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RentCalculationServiceTest {
+
+    @Mock
+    private PropertyService propertyService;
+
+    @InjectMocks
+    private RentCalculationService rentCalculationService;
+
+    private Player owner;
+    private Player renter;
+    private HouseableProperty property;
+
+    @BeforeEach
+    void setUp() {
+        // Setup test data
+        owner = new Player("owner123", "Owner");
+        renter = new Player("renter123", "Renter");
+
+        property = new HouseableProperty(
+            1,                // id
+            owner.getId(),    // ownerId
+            "Test Street",    // name
+            100,             // purchasePrice
+            10,              // baseRent
+            50,              // rent1House
+            150,             // rent2Houses
+            450,             // rent3Houses
+            625,             // rent4Houses
+            750,             // rentHotel
+            50,              // housePrice
+            50,              // hotelPrice
+            50,              // mortgageValue
+            false,           // isMortgaged
+            "test_image",    // image
+            1                // position
+        );
+    }
+
+    @Test
+    void calculateRent_WithValidParameters_ReturnsBaseRent() {
+        // Act
+        int rent = rentCalculationService.calculateRent(property, owner, renter);
+
+        // Assert
+        assertEquals(10, rent, "Rent should be equal to base rent for houseable property");
+    }
+
+    @Test
+    void calculateRent_WithNullProperty_ReturnsZero() {
+        // Act
+        int rent = rentCalculationService.calculateRent(null, owner, renter);
+
+        // Assert
+        assertEquals(0, rent, "Rent should be zero when property is null");
+    }
+
+    @Test
+    void calculateRent_WithNullOwner_ReturnsZero() {
+        // Act
+        int rent = rentCalculationService.calculateRent(property, null, renter);
+
+        // Assert
+        assertEquals(0, rent, "Rent should be zero when owner is null");
+    }
+
+    @Test
+    void calculateRent_WithNullRenter_ReturnsZero() {
+        // Act
+        int rent = rentCalculationService.calculateRent(property, owner, null);
+
+        // Assert
+        assertEquals(0, rent, "Rent should be zero when renter is null");
+    }
+} 

--- a/src/test/java/at/aau/serg/monopoly/websoket/RentCollectionServiceTest.java
+++ b/src/test/java/at/aau/serg/monopoly/websoket/RentCollectionServiceTest.java
@@ -1,0 +1,179 @@
+package at.aau.serg.monopoly.websoket;
+
+import model.Player;
+import model.properties.BaseProperty;
+import model.properties.HouseableProperty;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RentCollectionServiceTest {
+
+    @Mock
+    private PropertyService propertyService;
+
+    @Mock
+    private RentCalculationService rentCalculationService;
+
+    @InjectMocks
+    private RentCollectionService rentCollectionService;
+
+    private Player owner;
+    private Player renter;
+    private HouseableProperty property;
+
+    @BeforeEach
+    void setUp() {
+        // Setup test data
+        owner = new Player("owner123", "Owner");
+        renter = new Player("renter123", "Renter");
+
+        property = new HouseableProperty(
+            1,                // id
+            owner.getId(),    // ownerId
+            "Test Street",    // name
+            100,             // purchasePrice
+            10,              // baseRent
+            50,              // rent1House
+            150,             // rent2Houses
+            450,             // rent3Houses
+            625,             // rent4Houses
+            750,             // rentHotel
+            50,              // housePrice
+            50,              // hotelPrice
+            50,              // mortgageValue
+            false,           // isMortgaged
+            "test_image",    // image
+            1                // position
+        );
+    }
+
+    @Test
+    void canCollectRent_WithValidParameters_ReturnsTrue() {
+        // Act
+        boolean result = rentCollectionService.canCollectRent(renter, property);
+
+        // Assert
+        assertTrue(result, "Should be able to collect rent with valid parameters");
+    }
+
+    @Test
+    void canCollectRent_WithNullRenter_ReturnsFalse() {
+        // Act
+        boolean result = rentCollectionService.canCollectRent(null, property);
+
+        // Assert
+        assertFalse(result, "Should not be able to collect rent with null renter");
+    }
+
+    @Test
+    void canCollectRent_WithNullProperty_ReturnsFalse() {
+        // Act
+        boolean result = rentCollectionService.canCollectRent(renter, null);
+
+        // Assert
+        assertFalse(result, "Should not be able to collect rent with null property");
+    }
+
+    @Test
+    void canCollectRent_WithUnownedProperty_ReturnsFalse() {
+        // Arrange
+        property.setOwnerId(null);
+
+        // Act
+        boolean result = rentCollectionService.canCollectRent(renter, property);
+
+        // Assert
+        assertFalse(result, "Should not be able to collect rent for unowned property");
+    }
+
+    @Test
+    void canCollectRent_WhenRenterOwnsProperty_ReturnsFalse() {
+        // Arrange
+        property.setOwnerId(renter.getId());
+
+        // Act
+        boolean result = rentCollectionService.canCollectRent(renter, property);
+
+        // Assert
+        assertFalse(result, "Should not be able to collect rent when renter owns the property");
+    }
+
+    @Test
+    void canCollectRent_WithMortgagedProperty_ReturnsFalse() {
+        // Arrange
+        property.setMortgaged(true);
+
+        // Act
+        boolean result = rentCollectionService.canCollectRent(renter, property);
+
+        // Assert
+        assertFalse(result, "Should not be able to collect rent for mortgaged property");
+    }
+
+    @Test
+    void collectRent_WithValidParameters_ReturnsTrue() {
+        // Arrange
+        when(propertyService.getPlayerById(owner.getId())).thenReturn(owner);
+        when(rentCalculationService.calculateRent(property, owner, renter)).thenReturn(10);
+        renter.addMoney(20); // Ensure renter has enough money
+
+        // Act
+        boolean result = rentCollectionService.collectRent(renter, property);
+
+        // Assert
+        assertTrue(result, "Should successfully collect rent");
+        assertEquals(10, owner.getMoney() - 1500, "Owner should receive rent amount");
+        assertEquals(1510, renter.getMoney(), "Renter should pay rent amount"); // 1500 (initial) + 20 (added) - 10 (rent)
+    }
+
+    @Test
+    void collectRent_WhenCannotCollectRent_ReturnsFalse() {
+        // Arrange
+        property.setMortgaged(true);
+
+        // Act
+        boolean result = rentCollectionService.collectRent(renter, property);
+
+        // Assert
+        assertFalse(result, "Should not collect rent when cannot collect rent");
+        verify(propertyService, never()).getPlayerById(any());
+        verify(rentCalculationService, never()).calculateRent(any(), any(), any());
+    }
+
+    @Test
+    void collectRent_WhenOwnerNotFound_ReturnsFalse() {
+        // Arrange
+        when(propertyService.getPlayerById(owner.getId())).thenReturn(null);
+
+        // Act
+        boolean result = rentCollectionService.collectRent(renter, property);
+
+        // Assert
+        assertFalse(result, "Should not collect rent when owner not found");
+        verify(rentCalculationService, never()).calculateRent(any(), any(), any());
+    }
+
+    @Test
+    void collectRent_WhenRenterHasInsufficientFunds_ReturnsFalse() {
+        // Arrange
+        when(propertyService.getPlayerById(owner.getId())).thenReturn(owner);
+        when(rentCalculationService.calculateRent(property, owner, renter)).thenReturn(2000);
+        renter.subtractMoney(renter.getMoney()); // Set renter's money to 0
+
+        // Act
+        boolean result = rentCollectionService.collectRent(renter, property);
+
+        // Assert
+        assertFalse(result, "Should not collect rent when renter has insufficient funds");
+        assertEquals(1500, owner.getMoney(), "Owner's money should not change");
+        assertEquals(0, renter.getMoney(), "Renter's money should not change");
+    }
+} 


### PR DESCRIPTION
Dier PR fügt die grundlege Sever-Logik für die Basismiete (ohne Häuser/Hotes) zahlen und erhalten hinzu.