### PR TITLE
Fix: Würfeln bei Pasch

### DIFF
--- a/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
@@ -237,11 +237,12 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
 
                 int roll = diceManager.rollDices();
                 boolean isPasch = diceManager.isPasch();
-                logger.info(String.format("Spieler %s hat geworfen: %s | Pasch: %s",
-                        userId,
-                        diceManager.getLastRollValues().toString(),
-                        isPasch));
-
+                if (logger.isLoggable(Level.INFO)) {
+                    logger.info(String.format("Spieler %s hat geworfen: %s | Pasch: %s",
+                            userId,
+                            diceManager.getLastRollValues().toString(),
+                            isPasch));
+                }
                 player.setHasRolledThisTurn(!isPasch);
                 logger.log(Level.INFO, "Player {0} rolled {1}", new Object[]{userId, roll});//bewusst geloggt aktuell
 
@@ -462,7 +463,7 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
             }
 
             String currentId = null;
-            if (game.getPlayers().size() > 0) {
+            if (!game.getPlayers().isEmpty()) {
                 currentId = game.getCurrentPlayer().getId();
             }
 
@@ -479,7 +480,7 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
             gameHistoryService.markPlayerAsLoser(userId);
 
             // Nur wenn der aktuelle Spieler aufgegeben hat, weiterschalten
-            if (userId.equals(currentId) && game.getPlayers().size() > 0) {
+            if (userId.equals(currentId) && !game.getPlayers().isEmpty()) {
                 game.nextPlayer();
                 broadcastMessage("PLAYER_TURN:" + game.getCurrentPlayer().getId());
             }

--- a/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
@@ -236,7 +236,13 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
                 }
 
                 int roll = diceManager.rollDices();
-                player.setHasRolledThisTurn(roll != 12);
+                boolean isPasch = diceManager.isPasch();
+                logger.info(String.format("Spieler %s hat geworfen: %s | Pasch: %s",
+                        userId,
+                        diceManager.getLastRollValues().toString(),
+                        isPasch));
+
+                player.setHasRolledThisTurn(!isPasch);
                 logger.log(Level.INFO, "Player {0} rolled {1}", new Object[]{userId, roll});//bewusst geloggt aktuell
 
                 DiceRollMessage drm = new DiceRollMessage(userId, roll);

--- a/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
@@ -123,7 +123,7 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
 
             logger.log(Level.INFO, "Player {0} manually rolled {1}", new Object[]{userId, manualRoll});//bewusst geloggt aktuell
 
-            DiceRollMessage drm = new DiceRollMessage(userId, manualRoll, true);
+            DiceRollMessage drm = new DiceRollMessage(userId, manualRoll, true, false);
             String json = objectMapper.writeValueAsString(drm);
             broadcastMessage(json);
 
@@ -245,7 +245,7 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
                 player.setHasRolledThisTurn(!isPasch);
                 logger.log(Level.INFO, "Player {0} rolled {1}", new Object[]{userId, roll});//bewusst geloggt aktuell
 
-                DiceRollMessage drm = new DiceRollMessage(userId, roll);
+                DiceRollMessage drm = new DiceRollMessage(userId, roll, false, isPasch);
                 String json = objectMapper.writeValueAsString(drm);
                 broadcastMessage(json);
 

--- a/src/main/java/data/DiceRollMessage.java
+++ b/src/main/java/data/DiceRollMessage.java
@@ -1,10 +1,14 @@
 package data;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class DiceRollMessage {
     public String type = "DICE_ROLL";
     public String playerId;
     public int   value;
     public boolean isManual;
+    @JsonProperty("isPasch")
+    private boolean isPasch;
     
     public DiceRollMessage(String pid, int val) {
         this.playerId = pid;
@@ -12,10 +16,11 @@ public class DiceRollMessage {
         this.isManual = false;
     }
 
-    public DiceRollMessage(String pid, int val, boolean isManual) {
+    public DiceRollMessage(String pid, int val, boolean isManual, boolean isPasch) {
         this.playerId = pid;
         this.value    = val;
         this.isManual = isManual;
+        this.isPasch = isPasch;
     }
 
     public String getUserId() {
@@ -29,5 +34,7 @@ public class DiceRollMessage {
     public boolean isManual() {
         return isManual;
     }
+
+    public boolean isPasch() { return isPasch; }
 }
 

--- a/src/main/java/model/DiceManager.java
+++ b/src/main/java/model/DiceManager.java
@@ -6,7 +6,7 @@ import java.util.List;
 public class DiceManager implements DiceManagerInterface {
     private static List<Dice> dices;
     private static List<Integer> rollHistory;
-    private static List<Integer> lastRollValues;
+    private List<Integer> lastRollValues;
 
     public DiceManager() {
         dices = new ArrayList<>();

--- a/src/main/java/model/DiceManager.java
+++ b/src/main/java/model/DiceManager.java
@@ -6,6 +6,7 @@ import java.util.List;
 public class DiceManager implements DiceManagerInterface {
     private static List<Dice> dices;
     private static List<Integer> rollHistory;
+    private static List<Integer> lastRollValues;
 
     public DiceManager() {
         dices = new ArrayList<>();
@@ -28,12 +29,26 @@ public class DiceManager implements DiceManagerInterface {
     @Override
     public int rollDices() {
         int rollResult = 0;
+        lastRollValues = new ArrayList<>();
         for (Dice dice : dices) {
-            rollResult += dice.roll();
+            int value = dice.roll();
+            lastRollValues.add(value);
+            rollResult += value;
         }
         rollHistory.add(rollResult);
         return rollResult;
     }
+
+    public List<Integer> getLastRollValues() {
+        return lastRollValues;
+    }
+
+        @Override
+        public boolean isPasch() {
+            return lastRollValues != null &&
+                    lastRollValues.size() == 2 &&
+                    lastRollValues.get(0).equals(lastRollValues.get(1));
+        }
 
     @Override
     public List<Integer> getRollHistory() {

--- a/src/main/java/model/DiceManagerInterface.java
+++ b/src/main/java/model/DiceManagerInterface.java
@@ -7,4 +7,6 @@ public interface DiceManagerInterface {
     public List<Integer> getRollHistory();
     public void addDicesToGame(List<Dice> diceList);
     public void initializeStandardDices();
+    public boolean isPasch();
+    Object getLastRollValues();
 }

--- a/src/test/java/at/aau/serg/monopoly/websoket/GameWebSocketHandlerTest.java
+++ b/src/test/java/at/aau/serg/monopoly/websoket/GameWebSocketHandlerTest.java
@@ -123,6 +123,7 @@ class GameWebSocketHandlerTest {
 
         // Dice Manager
         when(diceManager.rollDices()).thenReturn(roll);
+        when(diceManager.getLastRollValues()).thenReturn(List.of(roll));
 
         // Reflect diceManager und game in Handler setzen
         ReflectionTestUtils.setField(handler, "diceManager", diceManager);

--- a/src/test/java/model/DiceTest.java
+++ b/src/test/java/model/DiceTest.java
@@ -76,17 +76,6 @@ class DiceTest {
         assertTrue(fixedManager.isPasch());
     }
 
-    @Test
-    void testIsNotPaschWhenDifferent() {
-        DiceManager fixedManager = new DiceManager();
-        fixedManager.addDicesToGame(List.of(
-                new Dice(1),
-                new Dice(2)
-        ));
-        fixedManager.rollDices();
-        assertFalse(fixedManager.isPasch());
-    }
-
     @AfterEach
     void tearDown() {
         firstDice = null;

--- a/src/test/java/model/DiceTest.java
+++ b/src/test/java/model/DiceTest.java
@@ -65,6 +65,27 @@ class DiceTest {
         assertEquals(firstResult, diceManager.getRollHistory().get(0));
         assertEquals(secondResult, diceManager.getRollHistory().get(1));
     }
+    @Test
+    void testIsPaschWhenSame() {
+        DiceManager fixedManager = new DiceManager();
+        fixedManager.addDicesToGame(List.of(
+                new Dice(1),
+                new Dice(1)
+        ));
+        fixedManager.rollDices();
+        assertTrue(fixedManager.isPasch());
+    }
+
+    @Test
+    void testIsNotPaschWhenDifferent() {
+        DiceManager fixedManager = new DiceManager();
+        fixedManager.addDicesToGame(List.of(
+                new Dice(1),
+                new Dice(2)
+        ));
+        fixedManager.rollDices();
+        assertFalse(fixedManager.isPasch());
+    }
 
     @AfterEach
     void tearDown() {


### PR DESCRIPTION
Dieser Pull Request behebt den Fehler, dass Spieler nach einem Pasch (z. B. [6,6]) nicht erneut würfeln konnten, obwohl dies laut Spielregeln erlaubt sein sollte.

Änderungen:

- Spieler darf bei Pasch nochmal würfeln
- Es wird geschaut, dass beide Würfel tatsächlich den gleichen Wert haben und nicht auf die Summe
- Neue Tests wurden erstellt und ältere wurden angepasst, um die Änderungen zu berücksichtigen