### PR TITLE
Clear chat when finished game

### DIFF
--- a/src/main/java/data/ClearChatMessage.java
+++ b/src/main/java/data/ClearChatMessage.java
@@ -1,0 +1,9 @@
+package data;
+
+import lombok.Data;
+
+@Data
+public class ClearChatMessage {
+    private final String type = "CLEAR_CHAT";
+    private final String reason = "Game has ended";
+}

--- a/src/main/resources/ChanceAndChestCards.json
+++ b/src/main/resources/ChanceAndChestCards.json
@@ -11,7 +11,7 @@
       "id": 2,
       "description": "Gehe direkt ins Gefängnis! Gehe nicht über Los! Ziehe nicht €200 ein",
       "action": "MOVE",
-      "field": 30
+      "field": 10
     },
     {
       "id": 3,
@@ -50,7 +50,7 @@
       "id": 1,
       "description": "Gehe direkt ins Gefängnis! Gehe nicht über Los! Ziehe nicht €200 ein",
       "action": "MOVE",
-      "field": 30
+      "field": 10
     },
     {
       "id": 2,


### PR DESCRIPTION
Clear chat when finished game 
For now added the function to the player gave up section so that it always happens - will be replaced to its correct position after the gameEnd has been implemented correctly. This pull request also includes a previously implemented function to sync all users game statistics after gameEnd to firebase (for now in player gave up section)

also solved the prison on 30 instead of 10 issue