### PR TITLE
Server side fix of the giveUp feature

### DIFF
--- a/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
@@ -524,7 +524,7 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
         return sanitized.length() > 100 ? sanitized.substring(0, 100) + "..." : sanitized;
     }
 
-    private void handleGiveUp(WebSocketSession session, JsonNode jsonNode) {
+    void handleGiveUp(WebSocketSession session, JsonNode jsonNode) {
         String quittingUserId = jsonNode.get("userId").asText();
 
         if (!game.isPlayerTurn(quittingUserId)) {

--- a/src/main/java/data/GiveUpMessage.java
+++ b/src/main/java/data/GiveUpMessage.java
@@ -1,0 +1,17 @@
+package data;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class GiveUpMessage {
+    private final String type = "GIVE_UP";
+    private final String userId;
+
+    @JsonCreator
+    public GiveUpMessage(@JsonProperty("userId") String userId) {
+        this.userId = userId;
+    }
+
+    public String getType() { return type; }
+    public String getUserId() { return userId; }
+}

--- a/src/main/java/data/HasWonMessage.java
+++ b/src/main/java/data/HasWonMessage.java
@@ -1,0 +1,18 @@
+package data;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class HasWonMessage {
+    private final String type = "HAS_WON";
+    private final String userId;
+
+    @JsonCreator
+    public HasWonMessage(@JsonProperty("userId") String userId) {
+        this.userId = userId;
+    }
+
+    public String getType()  { return type; }
+    public String getUserId(){ return userId; }
+}
+

--- a/src/main/java/model/Game.java
+++ b/src/main/java/model/Game.java
@@ -111,6 +111,36 @@ public class Game {
         return false;
     }
 
+    public void giveUp(String playerId) {
+        // Find the index of the player who sent GIVE_UP
+        int idx = -1;
+        for (int i = 0; i < players.size(); i++) {
+            if (players.get(i).getId().equals(playerId)) {
+                idx = i;
+                break;
+            }
+        }
+        if (idx < 0) return;
+
+        players.remove(idx);
+
+        // If we remove the current player than the next turn is still the same index
+        if (idx == currentPlayerIndex) {
+
+            // If we were at the end -> back to 0
+            if (currentPlayerIndex >= players.size()) {
+                currentPlayerIndex = 0;
+            }
+        } else if (idx < currentPlayerIndex) {
+            currentPlayerIndex--;
+        }
+
+        // Reset hasRolled
+        if (!players.isEmpty()) {
+            players.get(currentPlayerIndex).setHasRolledThisTurn(false);
+        }
+    }
+
     /**
      * Beendet das Spiel und setzt den Gewinner
      * @param winnerId Die ID des Gewinners

--- a/src/test/java/at/aau/serg/monopoly/websoket/GameWebSocketHandlerGiveUpTest.java
+++ b/src/test/java/at/aau/serg/monopoly/websoket/GameWebSocketHandlerGiveUpTest.java
@@ -1,0 +1,182 @@
+package at.aau.serg.monopoly.websoket;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import data.GiveUpMessage;
+import data.HasWonMessage;
+import model.Game;
+import model.Player;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+        import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+        import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class GameWebSocketHandlerGiveUpTest {
+
+    @InjectMocks
+    private GameWebSocketHandler handler;
+
+    @Mock private Game game;
+    @Mock private WebSocketSession session;
+    @Mock private Player quittingPlayer;
+    @Mock private Player remainingPlayer;
+    @Captor private ArgumentCaptor<TextMessage> messageCaptor;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // inject our mocks
+        ReflectionTestUtils.setField(handler, "game", game);
+        handler.sessions.clear();
+        handler.sessions.add(session);
+
+        when(session.getId()).thenReturn("session1");
+        when(session.isOpen()).thenReturn(true);
+
+        handler.sessionToUserId.clear();
+        handler.sessionToUserId.put("session1", "session1");
+    }
+
+    @Test
+    void giveUp_notYourTurn_sendsError() throws Exception {
+        // Arrange
+        JsonNode json = mapper.readTree("{\"userId\":\"session1\"}");
+        when(game.isPlayerTurn("session1")).thenReturn(false);
+
+        // Act
+        handler.handleGiveUp(session, json);
+
+        // Assert: error sent back to same session
+        verify(session).sendMessage(messageCaptor.capture());
+        String payload = messageCaptor.getValue().getPayload();
+        assertTrue(payload.contains("\"type\":\"ERROR\""));
+        assertTrue(payload.contains("You can only give up on your turn"));
+        // no game.giveUp
+        verify(game, never()).giveUp(any());
+    }
+
+    @Test
+    void giveUp_multiplePlayers_broadcastsGiveUpAndGameState() throws Exception {
+        // Arrange: it's your turn
+        JsonNode json = mapper.readTree("{\"userId\":\"session1\"}");
+        when(game.isPlayerTurn("session1")).thenReturn(true);
+
+        List<Player> players = Arrays.asList(quittingPlayer, remainingPlayer);
+        when(game.getPlayers()).thenReturn(players);
+        when(game.getPlayerInfo()).thenReturn(Collections.emptyList());
+        when(game.getCurrentPlayer()).thenReturn(remainingPlayer);
+        when(remainingPlayer.getId()).thenReturn("remainingId");
+
+        // Act
+        handler.handleGiveUp(session, json);
+
+        // Assert: game.giveUp called
+        verify(game).giveUp("session1");
+
+        // We expect exactly 3 sendMessage calls:
+        // 1) GIVE_UP
+        // 2) GAME_STATE
+        // 3) PLAYER_TURN
+        verify(session, times(3)).sendMessage(messageCaptor.capture());
+
+        List<TextMessage> sent = messageCaptor.getAllValues();
+        assertEquals(3, sent.size());
+
+        // 1st message = GIVE_UP
+        String giveUpPayload = sent.get(0).getPayload();
+        assertTrue(giveUpPayload.contains("\"type\":\"GIVE_UP\""));
+        assertTrue(giveUpPayload.contains("\"userId\":\"session1\""));
+
+        // 2nd message = GAME_STATE:
+        String gameStatePayload = sent.get(1).getPayload();
+        assertTrue(gameStatePayload.startsWith("GAME_STATE:"));
+
+        // 3rd message = PLAYER_TURN:
+        String turnPayload = sent.get(2).getPayload();
+        assertTrue(turnPayload.startsWith("PLAYER_TURN:"));
+    }
+
+
+    @Test
+    void giveUp_lastPlayer_sendsHasWonAndEndGame() throws Exception {
+        // Arrange: it's your turn
+        JsonNode json = mapper.readTree("{\"userId\":\"session1\"}");
+        when(game.isPlayerTurn("session1")).thenReturn(true);
+        // after removal only one player left
+        when(game.getPlayers()).thenReturn(Collections.singletonList(remainingPlayer));
+        when(remainingPlayer.getId()).thenReturn("winner1");
+
+        // Act
+        handler.handleGiveUp(session, json);
+
+        // Assert: game.giveUp called
+        verify(game).giveUp("session1");
+
+        // We expect exactly 2 sendMessage calls: HAS_WON and CLEAR_CHAT
+        verify(session, times(2)).sendMessage(messageCaptor.capture());
+
+        List<TextMessage> sent = messageCaptor.getAllValues();
+        assertEquals(2, sent.size());
+
+        // 1) The first must be the HasWonMessage
+        String hasWonPayload = sent.get(0).getPayload();
+        HasWonMessage parsed = mapper.readValue(hasWonPayload, HasWonMessage.class);
+        assertEquals("winner1", parsed.getUserId());
+
+        // 2) The second can be the clear-chat JSON (we just assert it has type CLEAR_CHAT)
+        String clearChat = sent.get(1).getPayload();
+        assertTrue(clearChat.contains("\"type\":\"CLEAR_CHAT\""));
+    }
+
+    @Test
+    void giveUp_serializationError_sendsError() throws Exception {
+        // Arrange
+        JsonNode json = mapper.readTree("{\"userId\":\"session1\"}");
+        when(game.isPlayerTurn("session1")).thenReturn(true);
+        when(game.getPlayers())
+                .thenReturn(Arrays.asList(quittingPlayer, remainingPlayer));
+        when(game.getPlayerInfo()).thenReturn(Collections.emptyList());
+        when(game.getCurrentPlayer()).thenReturn(remainingPlayer);
+        when(remainingPlayer.getId()).thenReturn("remainingId");
+        ObjectMapper mockMapper = mock(ObjectMapper.class);
+        ReflectionTestUtils.setField(handler, "objectMapper", mockMapper);
+        when(mockMapper.writeValueAsString(any()))
+                .thenThrow(new JsonProcessingException("serialize-fail") {});
+
+        // Act
+        handler.handleGiveUp(session, json);
+
+        // Assert
+        // 1) game.giveUp must still have been called
+        verify(game).giveUp("session1");
+
+        // 2) Since serialization failed, we should send exactly one ERROR to the session
+        verify(session, times(1)).sendMessage(messageCaptor.capture());
+        String errorPayload = messageCaptor.getValue().getPayload();
+        assertTrue(errorPayload.contains("\"type\":\"ERROR\""),
+                "Expected an ERROR message");
+        assertTrue(errorPayload.contains("Server error processing give up"),
+                "Expected our give-up error text");
+    }
+
+
+}

--- a/src/test/java/model/GameTest.java
+++ b/src/test/java/model/GameTest.java
@@ -278,4 +278,78 @@ class GameTest {
         String winner = gameWinnerEqualMoney.determineWinner();
         assertNotNull(winner);
     }
+
+    @Test
+    void testGiveUpCurrentPlayerRemovedAdvancesTurnCorrectly() {
+        // Arrange: Player B's turn
+        game.addPlayer("A", "Alice");
+        game.addPlayer("B", "Bob");
+        game.addPlayer("C", "Carol");
+        game.setCurrentPlayerIndex(1);
+        game.getCurrentPlayer().setHasRolledThisTurn(true);
+
+        // Act: B gives up
+        game.giveUp("B");
+
+        // Assert: players list is now [A, C]
+        assertThat(game.getPlayers())
+                .extracting(Player::getId)
+                .containsExactly("A", "C");
+        assertThat(game.getCurrentPlayer().getId()).isEqualTo("C");
+        assertThat(game.getCurrentPlayer().hasRolledThisTurn()).isFalse();
+    }
+
+    @Test
+    void testGiveUpNonCurrentBeforeIndexShiftsTurnBack() {
+        // Arrange: Player C’s turn
+        game.addPlayer("A", "Alice");
+        game.addPlayer("B", "Bob");
+        game.addPlayer("C", "Carol");
+        game.setCurrentPlayerIndex(2);
+
+        // Act: B gives up
+        game.giveUp("B");
+
+        // Assert: players now [A, C]
+        assertThat(game.getPlayers())
+                .extracting(Player::getId)
+                .containsExactly("A", "C");
+        assertThat(game.getCurrentPlayer().getId()).isEqualTo("C");
+    }
+
+    @Test
+    void testGiveUpNonCurrentAfterIndexLeavesTurnAlone() {
+        // Arrange: Player A's turn
+        game.addPlayer("A", "Alice");
+        game.addPlayer("B", "Bob");
+        game.addPlayer("C", "Carol");
+        game.setCurrentPlayerIndex(0);
+
+        // Act: C gives up
+        game.giveUp("C");
+
+        // Assert: players now [A, B]
+        assertThat(game.getPlayers())
+                .extracting(Player::getId)
+                .containsExactly("A", "B");
+        assertThat(game.getCurrentPlayer().getId()).isEqualTo("A");
+    }
+
+    @Test
+    void testGiveUpLastRemainingPlayer() {
+        // Arrange: Player A’s turn
+        game.addPlayer("A", "Alice");
+        game.addPlayer("B", "Bob");
+        game.setCurrentPlayerIndex(0);
+
+        // Act: A gives up
+        game.giveUp("A");
+
+        // Assert: only B remains
+        assertThat(game.getPlayers())
+                .extracting(Player::getId)
+                .containsExactly("B");
+        assertThat(game.getCurrentPlayer().getId()).isEqualTo("B");
+    }
+
 }


### PR DESCRIPTION
# Description
This PR finally fixes the issues with the give up button. Giving up now works as expected which means ...
- ... that a player that gives up is removed from the game
- ... that the turn is given onto the next player
- ... that if there are more than two players they can continue playing normally
- ... that the winner gets a win in our stats
___
# Changes
- Added a giveUp method in Game to pass around the index after a player gives up
- Added two DTOs
- Changed the implementation of the handleGiveUp method to make it work as expected
- Added unit tests and updated old ones