### PR TITLE
Fix Kartentausch - Aktualisierung des Eigentums

### DIFF
--- a/src/main/java/at/aau/serg/monopoly/websoket/DealService.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/DealService.java
@@ -51,23 +51,23 @@ public class DealService {
         return proposal;
     }
 
-    public void executeTrade(DealResponseMessage response) {
+    public DealProposalMessage executeTrade(DealResponseMessage response) {
         if (game == null) {
             logger.warning("Game instance is not set in DealService.");
-            return;
+            return null;
         }
 
         DealProposalMessage proposal = getPendingDeal(response);
         if (proposal == null) {
             logger.warning("No saved deal for response from " + response.getFromPlayerId() + " to " + response.getToPlayerId());
-            return;
+            return null;
         }
 
         Player sender = game.getPlayerById(proposal.getFromPlayerId()).orElse(null);
         Player receiver = game.getPlayerById(proposal.getToPlayerId()).orElse(null);
         if (sender == null || receiver == null) {
             logger.warning("Sender or receiver not found");
-            return;
+            return null;
         }
 
         // Eigentum vom Sender → Empfänger
@@ -101,5 +101,8 @@ public class DealService {
         removeProposal(response.getFromPlayerId());
 
         logger.info("Trade executed between " + sender.getName() + " and " + receiver.getName());
+
+        // Proposal zurückgeben
+        return proposal;
     }
 }

--- a/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
@@ -330,7 +330,7 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
                         + " to " + response.getToPlayerId());
 
                 if (response.getResponseType() == DealResponseType.ACCEPT) {
-                    // Proposal speichern
+
                     DealProposalMessage proposal = dealService.executeTrade(response);
 
                     if (proposal != null) {

--- a/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
@@ -295,19 +295,6 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
                 }
                 return;
             }
-            if (payload.contains("\"type\":\"DEAL_PROPOSAL\"")) {
-                DealProposalMessage deal = objectMapper.readValue(payload, DealProposalMessage.class);
-                logger.info("Received deal proposal from " + deal.getFromPlayerId());
-                dealService.saveProposal(deal);
-
-                WebSocketSession targetSession = findSessionByPlayerId(deal.getToPlayerId());
-                if (targetSession != null) {
-                    sendMessageToSession(targetSession, payload);
-                } else {
-                    logger.warning("Target player session not found for deal proposal");
-                }
-                return;
-            }
 
             if (payload.contains("\"type\":\"DEAL_PROPOSAL\"")) {
                 DealProposalMessage deal = objectMapper.readValue(payload, DealProposalMessage.class);


### PR DESCRIPTION
Dieser PR behebt einen Fehler in der Tauschfunktion, da die Aktualisierung der Eigentumsverhältnisse bisher nicht vollständig korrekt umgesetzt war.
Selbstverständlich wurden auch Tests geschrieben, um alles zu prüfen.
Die Counter-Funktion benötigt noch einen Fix, da sie aktuell noch nicht einwandfrei funktioniert.