### PR TITLE
263 profile userprofile aktualisieren zusätzlich zum leaderboard server

### DIFF
--- a/src/main/java/at/aau/serg/monopoly/firebase/LeaderboardService.java
+++ b/src/main/java/at/aau/serg/monopoly/firebase/LeaderboardService.java
@@ -17,229 +17,94 @@ import java.util.concurrent.ExecutionException;
 public class LeaderboardService {
 
     private static final String USERS_COLLECTION = "users";
-    private static final String GAME_HISTORY_COLLECTION = "gameHistory";
     private static final String LEADERBOARD_WINS = "leaderboard_wins";
     private static final String LEADERBOARD_LEVEL = "leaderboard_level";
     private static final String LEADERBOARD_MONEY = "leaderboard_averageMoney";
     private static final String LEADERBOARD_HIGH_MONEY = "leaderboard_highestMoney";
     private static final String LEADERBOARD_GAMES_PLAYED = "leaderboard_gamesPlayed";
-
     private static final int LEADERBOARD_SIZE = 50;
 
-
-    Firestore getFirestore() {
-        return FirestoreClient.getFirestore();
-    }
-
-    /**
-     * Aktualisiert alle Leaderboards ... einmal am Tag - firebase-free sonst schnell die reqeusts verbraucht
-     */
-    @Scheduled(fixedRate = 86400000) // wegen begrenzter Requestanzahl in firebase-free
+    @Scheduled(fixedRate = 86400000)
     public void updateAllLeaderboards() {
         log.info("Starte Leaderboard-Aktualisierung: " + new Date());
         try {
-            Firestore firestore = getFirestore();
+            Firestore firestore = FirestoreClient.getFirestore();
             if (firestore == null) {
                 log.severe("Firestore ist nicht initialisiert");
                 return;
             }
 
-            updateAllUserStats();
-            updateWinsLeaderboard();
-            updateLevelLeaderboard();
-            updateMoneyLeaderboard();
-            updateHighMoneyLeaderboard();
-            updateGamesPlayedLeaderboard();
+            updateWinsLeaderboard(firestore);
+            updateLevelLeaderboard(firestore);
+            updateMoneyLeaderboard(firestore);
+            updateHighMoneyLeaderboard(firestore);
+            updateGamesPlayedLeaderboard(firestore);
 
-            log.info("Leaderboard-Aktualisierung erfolgreich abgeschlossen: " + new Date());
+            log.info("Leaderboard-Aktualisierung abgeschlossen");
         } catch (Exception e) {
             log.severe("Fehler bei Leaderboard-Aktualisierung: " + e.getMessage());
         }
     }
-    /**
-     * Aktualisiert  Statistiken für alle Benutzer basierend auf ihrer GameHistory
-     */
-    void updateAllUserStats() {
+
+    void updateWinsLeaderboard(Firestore firestore) {
+        updateLeaderboard(firestore, "wins", LEADERBOARD_WINS);
+    }
+
+    void updateLevelLeaderboard(Firestore firestore) {
+        updateLeaderboard(firestore, "level", LEADERBOARD_LEVEL);
+    }
+
+    void updateMoneyLeaderboard(Firestore firestore) {
+        updateLeaderboard(firestore, "averageMoney", LEADERBOARD_MONEY);
+    }
+
+    void updateHighMoneyLeaderboard(Firestore firestore) {
+        updateLeaderboard(firestore, "highestMoney", LEADERBOARD_HIGH_MONEY);
+    }
+
+    void updateGamesPlayedLeaderboard(Firestore firestore) {
+        updateLeaderboard(firestore, "gamesPlayed", LEADERBOARD_GAMES_PLAYED);
+    }
+
+    void updateLeaderboard(Firestore firestore, String fieldName, String leaderboardCollection) {
         try {
-            Firestore firestore = getFirestore();
-            CollectionReference usersCollection = firestore.collection(USERS_COLLECTION);
-            ApiFuture<QuerySnapshot> querySnapshot = usersCollection.get();
-
-            for (DocumentSnapshot userDoc : querySnapshot.get().getDocuments()) {
-                String userId = userDoc.getId();
-                updateUserStats(userId, firestore);
-            }
-        } catch (InterruptedException | ExecutionException e) {
-            log.severe("Fehler beim Aktualisieren der Benutzerstatistiken: " + e.getMessage());
-            Thread.currentThread().interrupt();
-        }
-    }
-
-    /**
-     * Aktualisiert die Statistiken für einen einzelnen Benutzer
-     */
-    void updateUserStats(String userId, Firestore firestore) {
-        try {
-            // Spielhistorie des Benutzers abrufen
-            CollectionReference historyRef = firestore.collection(USERS_COLLECTION)
-                    .document(userId).collection(GAME_HISTORY_COLLECTION);
-            ApiFuture<QuerySnapshot> historySnapshot = historyRef.get();
-            List<QueryDocumentSnapshot> games = historySnapshot.get().getDocuments();
-
-            if (games.isEmpty()) {
-                return; // Keine Spielhistorie vorhanden
-            }
-
-            // Statistiken berechnen
-            int wins = 0;
-            int totalGames = games.size();
-            int totalMoney = 0;
-            int highestMoney = 0;
-
-            for (DocumentSnapshot game : games) {
-                Map<String, Object> gameData = game.getData();
-                if (gameData == null) continue;
-
-                // Gewonnene Spiele zählen
-                if (Boolean.TRUE.equals(gameData.get("won"))) {
-                    wins++;
-                }
-
-                // Geld tracken
-                if (gameData.get("endMoney") != null) {
-                    int endMoney = ((Number) gameData.get("endMoney")).intValue();
-                    totalMoney += endMoney;
-                    highestMoney = Math.max(highestMoney, endMoney);
-                }
-
-            }
-
-            // Durchschnittliches Geld berechnen
-            int averageMoney = totalGames > 0 ? totalMoney / totalGames : 0;
-
-            int level = totalGames / 2;
-
-            // Aktualisierte Statistiken in Firebase speichern
-            DocumentReference userRef = firestore.collection(USERS_COLLECTION).document(userId);
-            Map<String, Object> updates = new HashMap<>();
-            updates.put("gamesPlayed", totalGames);
-            updates.put("wins", wins);
-            updates.put("level", level);
-            updates.put("averageMoney", averageMoney);
-            updates.put("highestMoney", highestMoney);
-
-            // Name aus vorhandenem Dokument beibehalten
-            DocumentSnapshot userDoc = userRef.get().get();
-            if (userDoc.exists() && userDoc.contains("name")) {
-                updates.put("name", userDoc.getString("name"));
-            }
-
-            userRef.set(updates, SetOptions.merge());
-
-        } catch (InterruptedException | ExecutionException e) {
-            log.severe("Fehler beim Aktualisieren der Statistiken für Benutzer " + userId + ": " + e.getMessage());
-            Thread.currentThread().interrupt();
-        }
-    }
-
-    /**
-     * sort based on gewonnenen Spielen
-     */
-    void updateWinsLeaderboard() {
-        updateLeaderboard("wins", LEADERBOARD_WINS);
-    }
-
-    /**
-     * sort based on erreichten Levels
-     */
-    void updateLevelLeaderboard() {
-        updateLeaderboard("level", LEADERBOARD_LEVEL);
-    }
-
-    /**
-     * sort based on durchschnittlichem Geld
-     */
-    void updateMoneyLeaderboard() {
-        updateLeaderboard("averageMoney", LEADERBOARD_MONEY);
-    }
-
-    /**
-     * sort based on meistes Geld
-     */
-    void updateHighMoneyLeaderboard() {
-        updateLeaderboard("highestMoney", LEADERBOARD_HIGH_MONEY);
-    }
-
-    /**
-     * sort based on gespielten Spielen
-     */
-    void updateGamesPlayedLeaderboard() {
-        updateLeaderboard("gamesPlayed", LEADERBOARD_GAMES_PLAYED);
-    }
-
-    /**
-     * Generische Methode zum aktualisieren eines Leaderboards
-     */
-    void updateLeaderboard(String fieldName, String leaderboardCollection) {
-        try {
-            Firestore firestore = FirestoreClient.getFirestore();
-
-            // Player nach dem angegebenen Feld absteigend sortieren
             ApiFuture<QuerySnapshot> query = firestore.collection(USERS_COLLECTION)
                     .orderBy(fieldName, Query.Direction.DESCENDING)
                     .limit(LEADERBOARD_SIZE)
                     .get();
 
             List<QueryDocumentSnapshot> users = query.get().getDocuments();
-
-            // Leaderboard-Sammlung leeren
             deleteCollection(firestore, leaderboardCollection);
 
-            // Neue Leaderboard-Einträge erstellen
             int rank = 1;
             for (DocumentSnapshot user : users) {
                 Map<String, Object> userData = user.getData();
                 if (userData == null) continue;
 
-                Map<String, Object> leaderboardEntry = new HashMap<>();
-                leaderboardEntry.put("userId", user.getId());
-                leaderboardEntry.put("name", userData.getOrDefault("name", "Unbekannt"));
-                leaderboardEntry.put("rank", rank);
-                leaderboardEntry.put(fieldName, userData.getOrDefault(fieldName, 0));
+                Map<String, Object> entry = new HashMap<>();
+                entry.put("userId", user.getId());
+                entry.put("name", userData.getOrDefault("name", "Unbekannt"));
+                entry.put("rank", rank);
+                entry.put(fieldName, userData.getOrDefault(fieldName, 0));
 
-
-                // In Leaderboard-Sammlung speichern
                 firestore.collection(leaderboardCollection)
                         .document(String.valueOf(rank))
-                        .set(leaderboardEntry);
-
+                        .set(entry);
                 rank++;
             }
 
-            log.info(leaderboardCollection + " wurde aktualisiert mit " + (rank-1) + " Einträgen");
-
+            log.info(leaderboardCollection + " aktualisiert");
         } catch (InterruptedException | ExecutionException e) {
-            log.severe("Fehler beim Aktualisieren des " + leaderboardCollection + ": " + e.getMessage());
+            log.severe("Fehler bei " + leaderboardCollection + ": " + e.getMessage());
             Thread.currentThread().interrupt();
         }
     }
 
-    /**
-     * Löscht alle Dokumente in einer Sammlung
-     */
     void deleteCollection(Firestore firestore, String collectionPath) throws ExecutionException, InterruptedException {
         CollectionReference collection = firestore.collection(collectionPath);
         ApiFuture<QuerySnapshot> future = collection.limit(100).get();
-        int deleted = 0;
-
-        List<QueryDocumentSnapshot> documents = future.get().getDocuments();
-        for (DocumentSnapshot document : documents) {
+        for (DocumentSnapshot document : future.get().getDocuments()) {
             document.getReference().delete();
-            deleted++;
-        }
-
-        if (deleted >= 100) {
-            deleteCollection(firestore, collectionPath);
         }
     }
 }

--- a/src/main/java/at/aau/serg/monopoly/firebase/UserStatisticsService.java
+++ b/src/main/java/at/aau/serg/monopoly/firebase/UserStatisticsService.java
@@ -1,0 +1,84 @@
+package at.aau.serg.monopoly.firebase;
+
+import com.google.api.core.ApiFuture;
+import com.google.cloud.firestore.*;
+import com.google.firebase.cloud.FirestoreClient;
+import lombok.extern.java.Log;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+
+@Service
+@Log
+public class UserStatisticsService {
+
+    private static final String USERS_COLLECTION = "users";
+    private static final String GAME_HISTORY_COLLECTION = "gameHistory";
+
+    public void updateStatsForUsers(List<String> userIds) {
+        try {
+            Firestore firestore = FirestoreClient.getFirestore();
+            if (firestore == null) {
+                log.severe("Firestore ist nicht initialisiert");
+                return;
+            }
+
+            for (String userId : userIds) {
+                updateUserStats(userId, firestore);
+            }
+        } catch (Exception e) {
+            log.severe("Fehler beim Aktualisieren der Benutzerstatistiken: " + e.getMessage());
+        }
+    }
+
+    void updateUserStats(String userId, Firestore firestore) {
+        try {
+            CollectionReference historyRef = firestore.collection(USERS_COLLECTION)
+                    .document(userId).collection(GAME_HISTORY_COLLECTION);
+            ApiFuture<QuerySnapshot> historySnapshot = historyRef.get();
+            List<QueryDocumentSnapshot> games = historySnapshot.get().getDocuments();
+
+            if (games.isEmpty()) return;
+
+            int wins = 0;
+            int totalGames = games.size();
+            int totalMoney = 0;
+            int highestMoney = 0;
+
+            for (DocumentSnapshot game : games) {
+                Map<String, Object> gameData = game.getData();
+                if (gameData == null) continue;
+
+                if (Boolean.TRUE.equals(gameData.get("won"))) wins++;
+                if (gameData.get("endMoney") != null) {
+                    int endMoney = ((Number) gameData.get("endMoney")).intValue();
+                    totalMoney += endMoney;
+                    highestMoney = Math.max(highestMoney, endMoney);
+                }
+            }
+
+            int averageMoney = totalGames > 0 ? totalMoney / totalGames : 0;
+            int level = totalGames / 2;
+
+            DocumentReference userRef = firestore.collection(USERS_COLLECTION).document(userId);
+            Map<String, Object> updates = new HashMap<>();
+            updates.put("gamesPlayed", totalGames);
+            updates.put("wins", wins);
+            updates.put("level", level);
+            updates.put("averageMoney", averageMoney);
+            updates.put("highestMoney", highestMoney);
+
+            DocumentSnapshot userDoc = userRef.get().get();
+            if (userDoc.exists() && userDoc.contains("name")) {
+                updates.put("name", userDoc.getString("name"));
+            }
+
+            userRef.set(updates, SetOptions.merge());
+
+        } catch (InterruptedException | ExecutionException e) {
+            log.severe("Fehler bei Statistiken für " + userId + ": " + e.getMessage());
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/src/main/java/at/aau/serg/monopoly/websoket/GameHistoryService.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/GameHistoryService.java
@@ -51,12 +51,11 @@ public class GameHistoryService {
      * @param userId          Die ID des Spielers
      * @param durationMinutes Die Dauer des Spiels in Minuten
      * @param endMoney        Das Geld des Spielers am Ende
-     * @param levelGained     Die gewonnenen Level
      * @param won             Ob der Spieler gewonnen hat
      * @return true, wenn das Speichern erfolgreich war, sonst false
      */
     public boolean saveGameHistory(String userId, int durationMinutes, int endMoney,
-                                   int levelGained, boolean won) {
+                                   boolean won) {
 
 
 
@@ -69,7 +68,6 @@ public class GameHistoryService {
             gameHistory.setUserId(userId);
             gameHistory.setDurationMinutes(durationMinutes);
             gameHistory.setEndMoney(endMoney);
-            gameHistory.setLevelGained(levelGained);
             gameHistory.setTimestamp(new Date());
             gameHistory.setWon(won);
 
@@ -98,10 +96,9 @@ public class GameHistoryService {
      * @param players         Die Liste der Spieler
      * @param durationMinutes Die Dauer des Spiels in Minuten
      * @param winnerId        Die ID des Gewinners (oder null, wenn kein Gewinner)
-     * @param levelGained     Die gewonnenen Level
      */
     public void saveGameHistoryForAllPlayers(java.util.List<Player> players, int durationMinutes,
-                                             String winnerId, int levelGained) {
+                                             String winnerId) {
         if (players == null || players.isEmpty()) {
             logger.warning("Keine Spieler zum Speichern der Spielhistorie vorhanden");
             return;
@@ -114,7 +111,6 @@ public class GameHistoryService {
                     player.getId(),
                     durationMinutes,
                     player.getMoney(),
-                    levelGained,
                     won
             );
         }
@@ -136,7 +132,6 @@ public class GameHistoryService {
             gameHistory.setUserId(userId);
             gameHistory.setDurationMinutes(0); // Spiel wurde aufgegeben - verhindert verfälschte Statistiken
             gameHistory.setEndMoney(0); // damit nicht die Statistik verfälscht wird durch gezieltes Nutzten des mechanismus
-            gameHistory.setLevelGained(0); // kein Levelgewinn
             gameHistory.setTimestamp(new Date());
             gameHistory.setWon(false); // Spieler hat verloren
 

--- a/src/main/java/at/aau/serg/monopoly/websoket/GameHistoryService.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/GameHistoryService.java
@@ -119,33 +119,13 @@ public class GameHistoryService {
     }
 
     /**
-     * Speichert einen Spielabbruch (Give Up) als verlorenes Spiel für einen Spieler
+     * Speichert einen Spielabbruch (Give Up) und Bankrupt als verlorenes Spiel für einen Spieler
      */
-    public void markPlayerAsLoser(String userId) {
-        try {
-            ensureGameHistorySubcollection(userId);
+    public void markPlayerAsLoser(String userId, int durationMinutes, int endMoney) {
 
-            Firestore firestore = FirestoreClient.getFirestore();
+        saveGameHistory(userId, durationMinutes, endMoney, false);
 
-            GameHistory gameHistory = new GameHistory();
-            gameHistory.setId(UUID.randomUUID().toString());
-            gameHistory.setUserId(userId);
-            gameHistory.setDurationMinutes(0); // Spiel wurde aufgegeben - verhindert verfälschte Statistiken
-            gameHistory.setEndMoney(0); // damit nicht die Statistik verfälscht wird durch gezieltes Nutzten des mechanismus
-            gameHistory.setTimestamp(new Date());
-            gameHistory.setWon(false); // Spieler hat verloren
+        logger.info("Spielabbruch als Niederlage für " + userId + " gespeichert.");
 
-            ApiFuture<WriteResult> result = firestore.collection(COLLECTION_NAME)
-                    .document(userId)
-                    .collection(SUBCOLLECTION_NAME)
-                    .document(gameHistory.getId())
-                    .set(gameHistory);
-
-            result.get(); // warten auf Abschluss
-            logger.info("Spielabbruch als Niederlage für " + userId + " gespeichert.");
-        } catch (InterruptedException | ExecutionException e) {
-            logger.log(Level.SEVERE, "Fehler beim Speichern des Spielabbruchs für " + userId, e);
-            Thread.currentThread().interrupt();
-        }
     }
 }

--- a/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
@@ -1,5 +1,6 @@
 package at.aau.serg.monopoly.websoket;
 
+import at.aau.serg.monopoly.firebase.UserStatisticsService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -59,6 +60,9 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
     private CheatService cheatService;
     @Autowired
     private DealService dealService;
+    @Autowired
+    private UserStatisticsService userStatisticsService;
+
 
     @PostConstruct
     public void init() {
@@ -619,16 +623,22 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
             // Beende das Spiel und erhalte die Spieldauer
             int durationMinutes = game.endGame(winnerId);
 
-            // Standard Level-Gewinn für alle Spieler
-            int levelGained = 1;
 
             // Speichere die Spielhistorie für alle Spieler
             gameHistoryService.saveGameHistoryForAllPlayers(
                     game.getPlayers(),
                     durationMinutes,
-                    winnerId,
-                    levelGained
+                    winnerId
             );
+
+
+            // Stats für beteiligte Spieler aktualisieren
+            List<String> playerIds = new ArrayList<>();
+            for (Player player : game.getPlayers()) {
+                playerIds.add(player.getId());
+            }
+            userStatisticsService.updateStatsForUsers(playerIds);
+
 
             // Informiere alle Spieler über das Spielende
             broadcastMessage(createJsonMessage("Das Spiel wurde beendet. Der Gewinner ist " +

--- a/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
@@ -714,14 +714,14 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
         }
 
         logger.log(Level.INFO, "Player {0} has given up", quittingUserId);
-        processPlayerGiveUp(quittingUserId);
+        processPlayerGiveUp(quittingUserId, 0,0);
     }
 
     // Helper method to handle giveUp
-    public void processPlayerGiveUp(String quittingUserId) {
+    public void processPlayerGiveUp(String quittingUserId, int durationMinutes, int endMoney) {
 
         //mark player as looser for firebase
-        gameHistoryService.markPlayerAsLoser(quittingUserId);
+        gameHistoryService.markPlayerAsLoser(quittingUserId, durationMinutes , endMoney);
 
         //handle give up in game logic
         game.giveUp(quittingUserId);
@@ -809,8 +809,9 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
                             new Object[]{ pid, e.getMessage() });
                 }
 
+                int playedDuration = game.getDurationPlayed();
                 // Process GIVE_UP
-                processPlayerGiveUp(pid);
+                processPlayerGiveUp(pid, playedDuration, p.getMoney());
             }
         }
     }

--- a/src/main/java/model/Game.java
+++ b/src/main/java/model/Game.java
@@ -185,6 +185,11 @@ public class Game {
         return (int) (durationMs / (60 * 1000));
     }
 
+    public int getDurationPlayed(){
+        long durationMs = new Date().getTime() - startTime.getTime();
+        return (int) (durationMs / (60 * 1000));
+    }
+
 
     public String determineWinner() {
         if (players.isEmpty()) {

--- a/src/test/java/at/aau/serg/monopoly/firebase/LeaderboardServiceTest.java
+++ b/src/test/java/at/aau/serg/monopoly/firebase/LeaderboardServiceTest.java
@@ -38,64 +38,6 @@ class LeaderboardServiceTest {
     }
 
     @Test
-    void testUpdateUserStats_withValidGames() throws Exception {
-        CollectionReference users = mock(CollectionReference.class);
-        DocumentReference userDoc = mock(DocumentReference.class);
-        CollectionReference history = mock(CollectionReference.class);
-        ApiFuture<QuerySnapshot> future = mock(ApiFuture.class);
-        QuerySnapshot snapshot = mock(QuerySnapshot.class);
-        QueryDocumentSnapshot doc1 = mock(QueryDocumentSnapshot.class);
-        QueryDocumentSnapshot doc2 = mock(QueryDocumentSnapshot.class);
-        DocumentSnapshot userSnapshot = mock(DocumentSnapshot.class);
-        ApiFuture<DocumentSnapshot> userFuture = mock(ApiFuture.class);
-
-        when(firestore.collection("users")).thenReturn(users);
-        when(users.document("uid")).thenReturn(userDoc);
-        when(userDoc.collection("gameHistory")).thenReturn(history);
-        when(history.get()).thenReturn(future);
-        when(future.get()).thenReturn(snapshot);
-        when(snapshot.getDocuments()).thenReturn(List.of(doc1, doc2));
-        when(doc1.getData()).thenReturn(Map.of("won", true, "endMoney", 2000));
-        when(doc2.getData()).thenReturn(Map.of("won", false, "endMoney", 1500));
-
-        when(userDoc.get()).thenReturn(userFuture);
-        when(userFuture.get()).thenReturn(userSnapshot);
-        when(userSnapshot.exists()).thenReturn(true);
-        when(userSnapshot.contains("name")).thenReturn(true);
-        when(userSnapshot.getString("name")).thenReturn("TestUser");
-
-        leaderboardService.updateUserStats("uid", firestore);
-
-        verify(userDoc).set(argThat((Map<String, Object> map) ->
-                map.get("wins").equals(1) &&
-                        map.get("highestMoney").equals(2000) &&
-                        map.get("averageMoney").equals(1750) &&
-                        map.get("gamesPlayed").equals(2) &&
-                        map.get("level").equals(1) &&
-                        map.get("name").equals("TestUser")
-        ), any(SetOptions.class));
-    }
-
-    @Test
-    void testUpdateUserStatsEdgeCase_emptyHistory() throws Exception {
-        CollectionReference users = mock(CollectionReference.class);
-        DocumentReference userDoc = mock(DocumentReference.class);
-        CollectionReference history = mock(CollectionReference.class);
-        ApiFuture<QuerySnapshot> future = mock(ApiFuture.class);
-        QuerySnapshot snapshot = mock(QuerySnapshot.class);
-
-        when(firestore.collection("users")).thenReturn(users);
-        when(users.document("uid")).thenReturn(userDoc);
-        when(userDoc.collection("gameHistory")).thenReturn(history);
-        when(history.get()).thenReturn(future);
-        when(future.get()).thenReturn(snapshot);
-        when(snapshot.getDocuments()).thenReturn(Collections.emptyList());
-
-        leaderboardService.updateUserStats("uid", firestore);
-        verify(userDoc, never()).set(anyMap(), any(SetOptions.class));
-    }
-
-    @Test
     void testUpdateLeaderboard_success() throws Exception {
         CollectionReference users = mock(CollectionReference.class);
         Query query = mock(Query.class);
@@ -103,7 +45,6 @@ class LeaderboardServiceTest {
         ApiFuture<QuerySnapshot> future = mock(ApiFuture.class);
         QuerySnapshot snapshot = mock(QuerySnapshot.class);
         QueryDocumentSnapshot userDoc = mock(QueryDocumentSnapshot.class);
-        mock(DocumentReference.class);
 
         Map<String, Object> userData = new HashMap<>();
         userData.put("wins", 3);
@@ -132,7 +73,7 @@ class LeaderboardServiceTest {
 
         when(lb.document(anyString())).thenReturn(docRef);
 
-        leaderboardService.updateLeaderboard("wins", "leaderboard_wins");
+        leaderboardService.updateLeaderboard(firestore, "wins","leaderboard_wins");
 
         verify(docRef).set(argThat((Map<String, Object> m) ->
                 m.get("name").equals("Tester") &&
@@ -147,20 +88,16 @@ class LeaderboardServiceTest {
         CollectionReference collection = mock(CollectionReference.class);
         Query limitedQuery = mock(Query.class);
         ApiFuture<QuerySnapshot> future1 = mock(ApiFuture.class);
-        ApiFuture<QuerySnapshot> future2 = mock(ApiFuture.class);
         QuerySnapshot snap1 = mock(QuerySnapshot.class);
-        QuerySnapshot snap2 = mock(QuerySnapshot.class);
         QueryDocumentSnapshot doc = mock(QueryDocumentSnapshot.class);
         DocumentReference docRef = mock(DocumentReference.class);
 
         when(firestore.collection("some")).thenReturn(collection);
         when(collection.limit(100)).thenReturn(limitedQuery);
-        when(limitedQuery.get()).thenReturn(future1, future2);
+        when(limitedQuery.get()).thenReturn(future1);
         when(future1.get()).thenReturn(snap1);
-        when(future2.get()).thenReturn(snap2);
         when(doc.getReference()).thenReturn(docRef);
         when(snap1.getDocuments()).thenReturn(Collections.nCopies(100, doc));
-        when(snap2.getDocuments()).thenReturn(Collections.emptyList());
 
         leaderboardService.deleteCollection(firestore, "some");
 

--- a/src/test/java/at/aau/serg/monopoly/firebase/UserStatisticsServiceTest.java
+++ b/src/test/java/at/aau/serg/monopoly/firebase/UserStatisticsServiceTest.java
@@ -1,0 +1,97 @@
+package at.aau.serg.monopoly.firebase;
+
+import com.google.api.core.ApiFuture;
+import com.google.cloud.firestore.*;
+import com.google.firebase.cloud.FirestoreClient;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.*;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserStatisticsServiceTest {
+
+    private UserStatisticsService userStatisticsService;
+    private Firestore firestore;
+
+    private static MockedStatic<FirestoreClient> firestoreClientMock;
+
+    @BeforeAll
+    static void initStaticMock() {
+        firestoreClientMock = Mockito.mockStatic(FirestoreClient.class);
+    }
+
+    @AfterAll
+    static void closeStaticMock() {
+        firestoreClientMock.close();
+    }
+
+    @BeforeEach
+    void setup() {
+        firestore = mock(Firestore.class);
+        userStatisticsService = new UserStatisticsService();
+        firestoreClientMock.when(FirestoreClient::getFirestore).thenReturn(firestore);
+    }
+
+    @Test
+    void testUpdateUserStats_withValidGames() throws Exception {
+        CollectionReference users = mock(CollectionReference.class);
+        DocumentReference userDoc = mock(DocumentReference.class);
+        CollectionReference history = mock(CollectionReference.class);
+        ApiFuture<QuerySnapshot> future = mock(ApiFuture.class);
+        QuerySnapshot snapshot = mock(QuerySnapshot.class);
+        QueryDocumentSnapshot doc1 = mock(QueryDocumentSnapshot.class);
+        QueryDocumentSnapshot doc2 = mock(QueryDocumentSnapshot.class);
+        DocumentSnapshot userSnapshot = mock(DocumentSnapshot.class);
+        ApiFuture<DocumentSnapshot> userFuture = mock(ApiFuture.class);
+
+        when(firestore.collection("users")).thenReturn(users);
+        when(users.document("uid")).thenReturn(userDoc);
+        when(userDoc.collection("gameHistory")).thenReturn(history);
+        when(history.get()).thenReturn(future);
+        when(future.get()).thenReturn(snapshot);
+        when(snapshot.getDocuments()).thenReturn(List.of(doc1, doc2));
+        when(doc1.getData()).thenReturn(Map.of("won", true, "endMoney", 2000));
+        when(doc2.getData()).thenReturn(Map.of("won", false, "endMoney", 1500));
+
+        when(userDoc.get()).thenReturn(userFuture);
+        when(userFuture.get()).thenReturn(userSnapshot);
+        when(userSnapshot.exists()).thenReturn(true);
+        when(userSnapshot.contains("name")).thenReturn(true);
+        when(userSnapshot.getString("name")).thenReturn("TestUser");
+
+        userStatisticsService.updateUserStats("uid", firestore);
+
+        verify(userDoc).set(argThat((Map<String, Object> map) ->
+                map.get("wins").equals(1) &&
+                        map.get("highestMoney").equals(2000) &&
+                        map.get("averageMoney").equals(1750) &&
+                        map.get("gamesPlayed").equals(2) &&
+                        map.get("level").equals(1) &&
+                        map.get("name").equals("TestUser")
+        ), any(SetOptions.class));
+    }
+
+    @Test
+    void testUpdateUserStatsEdgeCase_emptyHistory() throws Exception {
+        CollectionReference users = mock(CollectionReference.class);
+        DocumentReference userDoc = mock(DocumentReference.class);
+        CollectionReference history = mock(CollectionReference.class);
+        ApiFuture<QuerySnapshot> future = mock(ApiFuture.class);
+        QuerySnapshot snapshot = mock(QuerySnapshot.class);
+
+        when(firestore.collection("users")).thenReturn(users);
+        when(users.document("uid")).thenReturn(userDoc);
+        when(userDoc.collection("gameHistory")).thenReturn(history);
+        when(history.get()).thenReturn(future);
+        when(future.get()).thenReturn(snapshot);
+        when(snapshot.getDocuments()).thenReturn(Collections.emptyList());
+
+        userStatisticsService.updateUserStats("uid", firestore);
+        verify(userDoc, never()).set(anyMap(), any(SetOptions.class));
+    }
+}

--- a/src/test/java/at/aau/serg/monopoly/websoket/GameHistoryServiceTest.java
+++ b/src/test/java/at/aau/serg/monopoly/websoket/GameHistoryServiceTest.java
@@ -47,7 +47,7 @@ class GameHistoryServiceTest {
             client.when(FirestoreClient::getFirestore).thenReturn(firestore);
 
             GameHistoryService service = new GameHistoryService();
-            boolean result = service.saveGameHistory("123", 45, 1500, 1, false);
+            boolean result = service.saveGameHistory("123", 45, 1500,  false);
 
             assertTrue(result);
             verify(gameDoc).set(any(GameHistory.class));
@@ -80,7 +80,7 @@ class GameHistoryServiceTest {
             client.when(FirestoreClient::getFirestore).thenReturn(firestore);
 
             GameHistoryService service = new GameHistoryService();
-            boolean result = service.saveGameHistory("123", 30, 1000, 1, true);
+            boolean result = service.saveGameHistory("123", 30, 1000, true);
 
             assertFalse(result);
         }
@@ -111,7 +111,7 @@ class GameHistoryServiceTest {
             client.when(FirestoreClient::getFirestore).thenReturn(firestore);
 
             GameHistoryService service = new GameHistoryService();
-            boolean result = service.saveGameHistory("123", 30, 1000, 1, false);
+            boolean result = service.saveGameHistory("123", 30, 1000, false);
 
             assertFalse(result);
         }
@@ -120,8 +120,8 @@ class GameHistoryServiceTest {
     @Test
     void testSaveGameHistoryForAllPlayers_emptyList() {
         GameHistoryService service = new GameHistoryService();
-        assertDoesNotThrow(() -> service.saveGameHistoryForAllPlayers(null, 30, "winnerId", 1));
-        assertDoesNotThrow(() -> service.saveGameHistoryForAllPlayers(List.of(), 30, "winnerId", 1));
+        assertDoesNotThrow(() -> service.saveGameHistoryForAllPlayers(null, 30, "winnerId"));
+        assertDoesNotThrow(() -> service.saveGameHistoryForAllPlayers(List.of(), 30, "winnerId"));
     }
 
     @Test
@@ -154,7 +154,7 @@ class GameHistoryServiceTest {
             client.when(FirestoreClient::getFirestore).thenReturn(firestore);
 
             GameHistoryService service = new GameHistoryService();
-            service.saveGameHistoryForAllPlayers(List.of(p1, p2), 40, "p2", 2);
+            service.saveGameHistoryForAllPlayers(List.of(p1, p2), 40, "p2");
 
             verify(gameDoc, atLeastOnce()).set(any(GameHistory.class));
         }
@@ -191,7 +191,7 @@ class GameHistoryServiceTest {
             client.when(FirestoreClient::getFirestore).thenReturn(firestore);
 
             GameHistoryService service = new GameHistoryService();
-            boolean result = service.saveGameHistory("123", 45, 1500, 1, false);
+            boolean result = service.saveGameHistory("123", 45, 1500,  false);
 
             assertTrue(result);
             verify(userDoc).set(Collections.emptyMap());
@@ -225,7 +225,7 @@ class GameHistoryServiceTest {
             client.when(FirestoreClient::getFirestore).thenReturn(firestore);
 
             GameHistoryService service = new GameHistoryService();
-            boolean result = service.saveGameHistory("123", 30, 1000, 1, true);
+            boolean result = service.saveGameHistory("123", 30, 1000,  true);
 
             assertFalse(result);
         }
@@ -257,7 +257,7 @@ class GameHistoryServiceTest {
             client.when(FirestoreClient::getFirestore).thenReturn(firestore);
 
             GameHistoryService service = new GameHistoryService();
-            service.markPlayerAsLoser("123");
+            service.markPlayerAsLoser("123",0,0);
 
             ArgumentCaptor<GameHistory> captor = ArgumentCaptor.forClass(GameHistory.class);
             verify(gameDoc).set(captor.capture());
@@ -297,7 +297,7 @@ class GameHistoryServiceTest {
             client.when(FirestoreClient::getFirestore).thenReturn(firestore);
 
             GameHistoryService service = new GameHistoryService();
-            assertDoesNotThrow(() -> service.markPlayerAsLoser("123"));
+            assertDoesNotThrow(() -> service.markPlayerAsLoser("123",0,0));
         } finally {
             Thread.interrupted();
         }
@@ -329,7 +329,7 @@ class GameHistoryServiceTest {
             client.when(FirestoreClient::getFirestore).thenReturn(firestore);
 
             GameHistoryService service = new GameHistoryService();
-            assertDoesNotThrow(() -> service.markPlayerAsLoser("123"));
+            assertDoesNotThrow(() -> service.markPlayerAsLoser("123", 0, 0));
         } finally {
             Thread.interrupted();
         }

--- a/src/test/java/at/aau/serg/monopoly/websoket/GameWebSocketHandlerEndGameTest.java
+++ b/src/test/java/at/aau/serg/monopoly/websoket/GameWebSocketHandlerEndGameTest.java
@@ -108,7 +108,7 @@ class GameWebSocketHandlerEndGameTest {
 
 
         GameWebSocketHandler spyHandler = spy(handler);
-        doNothing().when(spyHandler).processPlayerGiveUp(anyString());
+        doNothing().when(spyHandler).processPlayerGiveUp(anyString(), anyInt(), anyInt());
 
         spyHandler.sessions.clear();
         spyHandler.sessions.add(session);
@@ -147,7 +147,7 @@ class GameWebSocketHandlerEndGameTest {
         ReflectionTestUtils.setField(handler, "objectMapper", spyMapper);
 
         GameWebSocketHandler spyHandler = spy(handler);
-        doNothing().when(spyHandler).processPlayerGiveUp(anyString());
+        doNothing().when(spyHandler).processPlayerGiveUp(anyString(),anyInt(), anyInt());
 
         spyHandler.sessions.clear();
         spyHandler.sessions.add(session);

--- a/src/test/java/at/aau/serg/monopoly/websoket/GiveUpWebSocketHandlerTest.java
+++ b/src/test/java/at/aau/serg/monopoly/websoket/GiveUpWebSocketHandlerTest.java
@@ -18,7 +18,7 @@ class GiveUpWebSocketHandlerTest {
         GameHistoryService service = new GameHistoryService();
 
         // Einfach aufrufen – mehr nicht
-        service.markPlayerAsLoser("test-user");
+        service.markPlayerAsLoser("test-user", 0,0);
 
         // Kein assert nötig – Test besteht, wenn keine Exception fliegt
         assertTrue(true, "Die Methode markPlayerAsLoser wurde ohne Exception ausgeführt");


### PR DESCRIPTION
userprofil wird jetzt nach jedem game für die entsprechenden spieler aktualisiert und es werden nur bei änderungen daten geschrieben. auch die bankrott logik wurde entsprechend angepasst dass die daten nun richtig in die firebase gespeichert werden. für die firebase sachen wie gewohnt keine tests für die neuen/geänderten klassen Tests erstellt.