### PR TITLE
Fix: Property Owners are now reset after the game ends

### DIFF
--- a/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
+++ b/src/main/java/at/aau/serg/monopoly/websoket/GameWebSocketHandler.java
@@ -429,6 +429,13 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
 
         diceManager = new DiceManager();
         diceManager.initializeStandardDices();
+
+        // Wieder JSON init für neue Runde
+        try {
+            propertyService.init();
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Failed to reset property state: {0}", e.getMessage());
+        }
     }
 
     void handleGiveUpFromClient(WebSocketSession session, JsonNode jsonNode) {


### PR DESCRIPTION
# Description
This PR adds a quick fix to reset the property owners after the game ends.
___
# Changes
- After the game ends: initialize PropertyService again